### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/421/168/965/421168965.geojson
+++ b/data/421/168/965/421168965.geojson
@@ -640,6 +640,9 @@
     },
     "wof:country":"GH",
     "wof:created":1459008788,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9e85ad63a214d0e0626bad768b163c7c",
     "wof:hierarchy":[
         {
@@ -651,7 +654,7 @@
         }
     ],
     "wof:id":421168965,
-    "wof:lastmodified":1566638440,
+    "wof:lastmodified":1582352129,
     "wof:name":"Accra",
     "wof:parent_id":1108759901,
     "wof:placetype":"locality",

--- a/data/421/191/769/421191769.geojson
+++ b/data/421/191/769/421191769.geojson
@@ -217,6 +217,9 @@
     },
     "wof:country":"GH",
     "wof:created":1459009709,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1bc3958155b5e6363eda59e0c96d3521",
     "wof:hierarchy":[
         {
@@ -228,7 +231,7 @@
         }
     ],
     "wof:id":421191769,
-    "wof:lastmodified":1566638445,
+    "wof:lastmodified":1582352129,
     "wof:name":"Winneba",
     "wof:parent_id":1108759853,
     "wof:placetype":"locality",

--- a/data/856/321/89/85632189.geojson
+++ b/data/856/321/89/85632189.geojson
@@ -967,6 +967,11 @@
     },
     "wof:country":"GH",
     "wof:country_alpha3":"GHA",
+    "wof:geom_alt":[
+        "meso",
+        "naturalearth",
+        "naturalearth-display-terrestrial-zoom6"
+    ],
     "wof:geomhash":"eeb8a85ec27808ee03c59ddd8f4c8ea8",
     "wof:hierarchy":[
         {
@@ -984,7 +989,7 @@
         "ewe",
         "gaa"
     ],
-    "wof:lastmodified":1566637781,
+    "wof:lastmodified":1582352119,
     "wof:name":"Ghana",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/713/19/85671319.geojson
+++ b/data/856/713/19/85671319.geojson
@@ -287,6 +287,9 @@
         "wk:page":"Northern Region (Ghana)"
     },
     "wof:country":"GH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"979005bdcc6a4b837709ae8457c2aa06",
     "wof:hierarchy":[
         {
@@ -305,7 +308,7 @@
         "ewe",
         "gaa"
     ],
-    "wof:lastmodified":1566637777,
+    "wof:lastmodified":1582352117,
     "wof:name":"Northern",
     "wof:parent_id":85632189,
     "wof:placetype":"region",

--- a/data/856/713/23/85671323.geojson
+++ b/data/856/713/23/85671323.geojson
@@ -293,6 +293,9 @@
         "wk:page":"Upper East Region"
     },
     "wof:country":"GH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f60c4c4bb92a06c51059271d8fbe2ea2",
     "wof:hierarchy":[
         {
@@ -311,7 +314,7 @@
         "ewe",
         "gaa"
     ],
-    "wof:lastmodified":1566637780,
+    "wof:lastmodified":1582352118,
     "wof:name":"Upper East",
     "wof:parent_id":85632189,
     "wof:placetype":"region",

--- a/data/856/713/27/85671327.geojson
+++ b/data/856/713/27/85671327.geojson
@@ -290,6 +290,9 @@
         "wk:page":"Upper West Region"
     },
     "wof:country":"GH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f747c1ce234ab0aeef304eced6e99844",
     "wof:hierarchy":[
         {
@@ -308,7 +311,7 @@
         "ewe",
         "gaa"
     ],
-    "wof:lastmodified":1566637777,
+    "wof:lastmodified":1582352117,
     "wof:name":"Upper West",
     "wof:parent_id":85632189,
     "wof:placetype":"region",

--- a/data/856/713/31/85671331.geojson
+++ b/data/856/713/31/85671331.geojson
@@ -314,6 +314,9 @@
         "wk:page":"Ashanti Region"
     },
     "wof:country":"GH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"30e4e4987207f9d078cfe28f6c50b494",
     "wof:hierarchy":[
         {
@@ -332,7 +335,7 @@
         "ewe",
         "gaa"
     ],
-    "wof:lastmodified":1566637778,
+    "wof:lastmodified":1582352118,
     "wof:name":"Ashanti",
     "wof:parent_id":85632189,
     "wof:placetype":"region",

--- a/data/856/713/37/85671337.geojson
+++ b/data/856/713/37/85671337.geojson
@@ -290,6 +290,9 @@
         "wk:page":"Brong-Ahafo Region"
     },
     "wof:country":"GH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c147674d7236a694f243f8a2d23a366c",
     "wof:hierarchy":[
         {
@@ -308,7 +311,7 @@
         "ewe",
         "gaa"
     ],
-    "wof:lastmodified":1566637779,
+    "wof:lastmodified":1582352118,
     "wof:name":"Brong Ahafo",
     "wof:parent_id":85632189,
     "wof:placetype":"region",

--- a/data/856/713/41/85671341.geojson
+++ b/data/856/713/41/85671341.geojson
@@ -293,6 +293,9 @@
         "wk:page":"Central Region (Ghana)"
     },
     "wof:country":"GH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f7d8b4985988a62698722c11b1ad7f43",
     "wof:hierarchy":[
         {
@@ -311,7 +314,7 @@
         "ewe",
         "gaa"
     ],
-    "wof:lastmodified":1566637780,
+    "wof:lastmodified":1582352118,
     "wof:name":"Central",
     "wof:parent_id":85632189,
     "wof:placetype":"region",

--- a/data/856/713/43/85671343.geojson
+++ b/data/856/713/43/85671343.geojson
@@ -287,6 +287,9 @@
         "wk:page":"Eastern Region (Ghana)"
     },
     "wof:country":"GH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6aa77dab3d6544b4ea28e96de54f6865",
     "wof:hierarchy":[
         {
@@ -305,7 +308,7 @@
         "ewe",
         "gaa"
     ],
-    "wof:lastmodified":1566637778,
+    "wof:lastmodified":1582352117,
     "wof:name":"Eastern",
     "wof:parent_id":85632189,
     "wof:placetype":"region",

--- a/data/856/713/47/85671347.geojson
+++ b/data/856/713/47/85671347.geojson
@@ -287,6 +287,9 @@
         "wk:page":"Western Region (Ghana)"
     },
     "wof:country":"GH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5216334d826bf0fea8ead75c15bf8d83",
     "wof:hierarchy":[
         {
@@ -305,7 +308,7 @@
         "ewe",
         "gaa"
     ],
-    "wof:lastmodified":1566637781,
+    "wof:lastmodified":1582352119,
     "wof:name":"Western",
     "wof:parent_id":85632189,
     "wof:placetype":"region",

--- a/data/856/713/53/85671353.geojson
+++ b/data/856/713/53/85671353.geojson
@@ -313,6 +313,9 @@
         "wk:page":"Greater Accra Region"
     },
     "wof:country":"GH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"68a9f1f0c882c5f1f27f6e513bbea9c8",
     "wof:hierarchy":[
         {
@@ -331,7 +334,7 @@
         "ewe",
         "gaa"
     ],
-    "wof:lastmodified":1566637779,
+    "wof:lastmodified":1582352118,
     "wof:name":"Greater Accra",
     "wof:parent_id":85632189,
     "wof:placetype":"region",

--- a/data/856/713/57/85671357.geojson
+++ b/data/856/713/57/85671357.geojson
@@ -296,6 +296,9 @@
         "wk:page":"Volta Region"
     },
     "wof:country":"GH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ebbc151f544171b69a521b72f5b4a7f3",
     "wof:hierarchy":[
         {
@@ -314,7 +317,7 @@
         "ewe",
         "gaa"
     ],
-    "wof:lastmodified":1566637776,
+    "wof:lastmodified":1582352116,
     "wof:name":"Volta",
     "wof:parent_id":85632189,
     "wof:placetype":"region",

--- a/data/857/655/59/85765559.geojson
+++ b/data/857/655/59/85765559.geojson
@@ -77,6 +77,10 @@
         "wd:id":"Q4999329"
     },
     "wof:country":"GH",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"c62baee8739fbf7fafbed9f0cebe3f18",
     "wof:hierarchy":[
         {
@@ -92,7 +96,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566637775,
+    "wof:lastmodified":1582352116,
     "wof:name":"Burma Camp",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/655/65/85765565.geojson
+++ b/data/857/655/65/85765565.geojson
@@ -142,6 +142,10 @@
         "qs_pg:id":316707
     },
     "wof:country":"GH",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"22f0c38a41a9d5788f108945c33ccfa1",
     "wof:hierarchy":[
         {
@@ -157,7 +161,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566637775,
+    "wof:lastmodified":1582352116,
     "wof:name":"Christiansborg",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/655/69/85765569.geojson
+++ b/data/857/655/69/85765569.geojson
@@ -72,6 +72,10 @@
         "qs_pg:id":1168006
     },
     "wof:country":"GH",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"80dfb5e4270823ac62b87b12dfc37c41",
     "wof:hierarchy":[
         {
@@ -87,7 +91,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566637775,
+    "wof:lastmodified":1582352116,
     "wof:name":"Nima",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/655/73/85765573.geojson
+++ b/data/857/655/73/85765573.geojson
@@ -218,6 +218,10 @@
         "wd:id":"Q740445"
     },
     "wof:country":"GH",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ed77fad7f68b2cc752a4415eacea0155",
     "wof:hierarchy":[
         {
@@ -233,7 +237,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566637775,
+    "wof:lastmodified":1582352116,
     "wof:name":"Ridge",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/890/432/205/890432205.geojson
+++ b/data/890/432/205/890432205.geojson
@@ -68,6 +68,9 @@
     },
     "wof:country":"GH",
     "wof:created":1469051932,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"13190a95ab512ab72751e93858a0dcf3",
     "wof:hierarchy":[
         {
@@ -79,7 +82,7 @@
         }
     ],
     "wof:id":890432205,
-    "wof:lastmodified":1566638450,
+    "wof:lastmodified":1582352129,
     "wof:name":"Akim Swedru",
     "wof:parent_id":1108759879,
     "wof:placetype":"locality",

--- a/data/890/444/261/890444261.geojson
+++ b/data/890/444/261/890444261.geojson
@@ -289,6 +289,9 @@
     },
     "wof:country":"GH",
     "wof:created":1469052462,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"dbeca6ca1bd40bfd7c3106a4e2cf6403",
     "wof:hierarchy":[
         {
@@ -300,7 +303,7 @@
         }
     ],
     "wof:id":890444261,
-    "wof:lastmodified":1566638449,
+    "wof:lastmodified":1582352129,
     "wof:name":"Tema",
     "wof:parent_id":1108759911,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.