### PR TITLE
gh concordances, placetype local, and more

### DIFF
--- a/data/110/875/977/1/1108759771.geojson
+++ b/data/110/875/977/1/1108759771.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.100245,
-    "geom:area_square_m":1232558840.496376,
+    "geom:area_square_m":1232559505.563932,
     "geom:bbox":"-1.622825,5.874113,-1.210422,6.314111",
     "geom:latitude":6.088506,
     "geom:longitude":-1.413816,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"GH.AH.AE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481329979,
-    "wof:geomhash":"df2065539f333654e0345094b62f5481",
+    "wof:geomhash":"9a302d7213040ecdc3b70d67ec70a3e5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108759771,
-    "wof:lastmodified":1627522152,
+    "wof:lastmodified":1695886621,
     "wof:name":"Adansi East",
     "wof:parent_id":85671331,
     "wof:placetype":"county",

--- a/data/110/875/977/3/1108759773.geojson
+++ b/data/110/875/977/3/1108759773.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.075035,
-    "geom:area_square_m":922524667.372368,
+    "geom:area_square_m":922524573.613244,
     "geom:bbox":"-1.795541,5.930012,-1.441073,6.351198",
     "geom:latitude":6.124821,
     "geom:longitude":-1.624967,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"GH.AH.AW"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481329981,
-    "wof:geomhash":"b92e2f811209cc24abb8f38f2dcdc39d",
+    "wof:geomhash":"1b3d3979d5a90d6788abeacfb81df0d8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108759773,
-    "wof:lastmodified":1627522152,
+    "wof:lastmodified":1695886622,
     "wof:name":"Adansi West",
     "wof:parent_id":85671331,
     "wof:placetype":"county",

--- a/data/110/875/977/5/1108759775.geojson
+++ b/data/110/875/977/5/1108759775.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.05945,
-    "geom:area_square_m":729635329.698175,
+    "geom:area_square_m":729635260.036816,
     "geom:bbox":"-1.712466,6.809711,-1.409881,7.16426",
     "geom:latitude":6.993586,
     "geom:longitude":-1.563028,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"GH.AH.AF"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481329982,
-    "wof:geomhash":"9171b5979efe5752472ebf01598e4d5c",
+    "wof:geomhash":"d034b46bb548300512a272c6aab94156",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108759775,
-    "wof:lastmodified":1627522153,
+    "wof:lastmodified":1695886622,
     "wof:name":"Afigya",
     "wof:parent_id":85671331,
     "wof:placetype":"county",

--- a/data/110/875/977/7/1108759777.geojson
+++ b/data/110/875/977/7/1108759777.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.056187,
-    "geom:area_square_m":689719513.909108,
+    "geom:area_square_m":689719302.424236,
     "geom:bbox":"-2.374759,6.711703,-2.058173,7.075934",
     "geom:latitude":6.908632,
     "geom:longitude":-2.211316,
@@ -118,9 +118,10 @@
         "hasc:id":"GH.AH.AN",
         "wd:id":"Q399850"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481329983,
-    "wof:geomhash":"165ffd3f4863bca439d124c93aa5cf5a",
+    "wof:geomhash":"84f416949a8c648219c261bf6d2c07c7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -130,7 +131,7 @@
         }
     ],
     "wof:id":1108759777,
-    "wof:lastmodified":1690921666,
+    "wof:lastmodified":1695886305,
     "wof:name":"Ahafo Ano North",
     "wof:parent_id":85671331,
     "wof:placetype":"county",

--- a/data/110/875/978/1/1108759781.geojson
+++ b/data/110/875/978/1/1108759781.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.093727,
-    "geom:area_square_m":1150501876.164454,
+    "geom:area_square_m":1150501999.500594,
     "geom:bbox":"-2.148222,6.730636,-1.811946,7.1632",
     "geom:latitude":6.924078,
     "geom:longitude":-1.962536,
@@ -108,9 +108,10 @@
         "hasc:id":"GH.AH.AS",
         "wd:id":"Q399853"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481329984,
-    "wof:geomhash":"2cfe7a5b9d58b4eca8be334847b0053f",
+    "wof:geomhash":"b511c4c606a97b2b13b60de140cb694f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -120,7 +121,7 @@
         }
     ],
     "wof:id":1108759781,
-    "wof:lastmodified":1690921669,
+    "wof:lastmodified":1695886306,
     "wof:name":"Ahafo Ano South",
     "wof:parent_id":85671331,
     "wof:placetype":"county",

--- a/data/110/875/978/3/1108759783.geojson
+++ b/data/110/875/978/3/1108759783.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.165537,
-    "geom:area_square_m":2034553974.671004,
+    "geom:area_square_m":2034553716.226714,
     "geom:bbox":"-1.97215,6.007876,-1.186804,6.531742",
     "geom:latitude":6.293655,
     "geom:longitude":-1.596909,
@@ -102,9 +102,10 @@
         "hasc:id":"GH.AH.AM",
         "wd:id":"Q454460"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481329986,
-    "wof:geomhash":"ca9826a99d212bb355c5c3f4875d19bd",
+    "wof:geomhash":"3768d6f645a0380c7bd28382c54a1dc3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -114,7 +115,7 @@
         }
     ],
     "wof:id":1108759783,
-    "wof:lastmodified":1690921670,
+    "wof:lastmodified":1695886306,
     "wof:name":"Amansie East",
     "wof:parent_id":85671331,
     "wof:placetype":"county",

--- a/data/110/875/978/5/1108759785.geojson
+++ b/data/110/875/978/5/1108759785.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.091099,
-    "geom:area_square_m":1119457006.975861,
+    "geom:area_square_m":1119457164.663474,
     "geom:bbox":"-2.094372,6.092281,-1.676784,6.606288",
     "geom:latitude":6.387286,
     "geom:longitude":-1.904203,
@@ -114,9 +114,10 @@
         "hasc:id":"GH.AH.AI",
         "wd:id":"Q425533"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481329987,
-    "wof:geomhash":"3b5260bb7aa42c588eb54ffffee163fc",
+    "wof:geomhash":"7ff4fe5ec78a50030bdd7f07896ca948",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":1108759785,
-    "wof:lastmodified":1690921670,
+    "wof:lastmodified":1695886306,
     "wof:name":"Amansie West",
     "wof:parent_id":85671331,
     "wof:placetype":"county",

--- a/data/110/875/978/7/1108759787.geojson
+++ b/data/110/875/978/7/1108759787.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.119473,
-    "geom:area_square_m":1466931215.991651,
+    "geom:area_square_m":1466931367.488987,
     "geom:bbox":"-1.310406,6.480325,-0.748303,7.037635",
     "geom:latitude":6.791324,
     "geom:longitude":-1.056404,
@@ -106,9 +106,10 @@
         "hasc:id":"GH.AH.AR",
         "wd:id":"Q720960"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481329988,
-    "wof:geomhash":"d50baf3519c19f5c4aa3b9ac9f75be2c",
+    "wof:geomhash":"171df88df85536674d2757c022eb3d09",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -118,7 +119,7 @@
         }
     ],
     "wof:id":1108759787,
-    "wof:lastmodified":1690921669,
+    "wof:lastmodified":1695886306,
     "wof:name":"Asante Akim North",
     "wof:parent_id":85671331,
     "wof:placetype":"county",

--- a/data/110/875/978/9/1108759789.geojson
+++ b/data/110/875/978/9/1108759789.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.095305,
-    "geom:area_square_m":1170902223.598673,
+    "geom:area_square_m":1170902223.598671,
     "geom:bbox":"-1.30140163918,6.20822953036,-0.900509956881,6.75600154037",
     "geom:latitude":6.492391,
     "geom:longitude":-1.110487,
@@ -99,9 +99,10 @@
         "hasc:id":"GH.AH.AU",
         "wd:id":"Q720966"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481329989,
-    "wof:geomhash":"31c852c61a7a3cf9de2c8c3635a16ddb",
+    "wof:geomhash":"dd8a5208fe27eb2b51a1244a618ec39c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":1108759789,
-    "wof:lastmodified":1566638248,
+    "wof:lastmodified":1695886306,
     "wof:name":"Asante Akim South",
     "wof:parent_id":85671331,
     "wof:placetype":"county",

--- a/data/110/875/979/1/1108759791.geojson
+++ b/data/110/875/979/1/1108759791.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.201879,
-    "geom:area_square_m":2479610080.804617,
+    "geom:area_square_m":2479609687.253891,
     "geom:bbox":"-2.448857,6.337209,-1.663592,6.979733",
     "geom:latitude":6.623658,
     "geom:longitude":-2.059519,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"GH.AH.AT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481329990,
-    "wof:geomhash":"d0a9f71ca034c2610beb3ab5edc608bc",
+    "wof:geomhash":"333a5b68e30da42c40aeb59e109af29e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108759791,
-    "wof:lastmodified":1627522154,
+    "wof:lastmodified":1695886623,
     "wof:name":"Atwima",
     "wof:parent_id":85671331,
     "wof:placetype":"county",

--- a/data/110/875/979/3/1108759793.geojson
+++ b/data/110/875/979/3/1108759793.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.058841,
-    "geom:area_square_m":722801525.492005,
+    "geom:area_square_m":722801383.293461,
     "geom:bbox":"-1.827756,6.466161,-1.332477,6.680185",
     "geom:latitude":6.572138,
     "geom:longitude":-1.583981,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"GH.AH.BK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481329991,
-    "wof:geomhash":"1029b9164950ded0b154d1bee076dcfb",
+    "wof:geomhash":"91240cade1a04beaac7d0952a00e9574",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108759793,
-    "wof:lastmodified":1627522154,
+    "wof:lastmodified":1695886623,
     "wof:name":"Bosomtwe/ Atwima/ Kwanwoma",
     "wof:parent_id":85671331,
     "wof:placetype":"county",

--- a/data/110/875/979/5/1108759795.geojson
+++ b/data/110/875/979/5/1108759795.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.05169,
-    "geom:area_square_m":634824284.441568,
+    "geom:area_square_m":634824765.118113,
     "geom:bbox":"-1.54599,6.418449,-1.245817,6.828817",
     "geom:latitude":6.669502,
     "geom:longitude":-1.38464,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"GH.AH.EJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481329993,
-    "wof:geomhash":"f06464828265428b98d1dc5f81f3005c",
+    "wof:geomhash":"8e4178d49630dbf423b77db3b4800ce4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108759795,
-    "wof:lastmodified":1627522154,
+    "wof:lastmodified":1695886623,
     "wof:name":"Ejisu Juaben",
     "wof:parent_id":85671331,
     "wof:placetype":"county",

--- a/data/110/875/979/9/1108759799.geojson
+++ b/data/110/875/979/9/1108759799.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.107289,
-    "geom:area_square_m":1315661452.776402,
+    "geom:area_square_m":1315661552.852151,
     "geom:bbox":"-1.68762,7.146352,-1.121215,7.62982",
     "geom:latitude":7.379723,
     "geom:longitude":-1.439432,
@@ -109,9 +109,10 @@
         "hasc:id":"GH.AH.ES",
         "wd:id":"Q688667"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481329994,
-    "wof:geomhash":"cff3d1a02e7f70bd1f925dbcd6cf34df",
+    "wof:geomhash":"9db0fe711102dadbed57ac1330d2602d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -121,7 +122,7 @@
         }
     ],
     "wof:id":1108759799,
-    "wof:lastmodified":1690921668,
+    "wof:lastmodified":1695886306,
     "wof:name":"Ejura/ Sekyeredumase",
     "wof:parent_id":85671331,
     "wof:placetype":"county",

--- a/data/110/875/980/1/1108759801.geojson
+++ b/data/110/875/980/1/1108759801.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.015124,
-    "geom:area_square_m":185739334.975946,
+    "geom:area_square_m":185739334.975943,
     "geom:bbox":"-1.696846,6.630943,-1.52479,6.756009",
     "geom:latitude":6.694023,
     "geom:longitude":-1.610251,
@@ -65,12 +65,13 @@
     "wof:concordances":{
         "hasc:id":"GH.AH.KM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:coterminous":[
         421168961
     ],
     "wof:country":"GH",
     "wof:created":1481329996,
-    "wof:geomhash":"b50944280bd5c694ec5c8132912af61d",
+    "wof:geomhash":"bff954bdbc6ace61cf4ab972ff18a27b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108759801,
-    "wof:lastmodified":1627522153,
+    "wof:lastmodified":1695886622,
     "wof:name":"Kumasi Metro",
     "wof:parent_id":85671331,
     "wof:placetype":"county",

--- a/data/110/875/980/3/1108759803.geojson
+++ b/data/110/875/980/3/1108759803.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.027665,
-    "geom:area_square_m":339677997.739136,
+    "geom:area_square_m":339677997.739135,
     "geom:bbox":"-1.71437876928,6.72364001241,-1.43162545996,6.88411269175",
     "geom:latitude":6.805547,
     "geom:longitude":-1.561791,
@@ -93,9 +93,10 @@
         "hasc:id":"GH.AH.KB",
         "wd:id":"Q688970"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481329997,
-    "wof:geomhash":"063ad8338ae27132992b085b69ae2e13",
+    "wof:geomhash":"c6dd9b8f48d556958c2a2ffb41194245",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1108759803,
-    "wof:lastmodified":1566638258,
+    "wof:lastmodified":1695886309,
     "wof:name":"Kwabre",
     "wof:parent_id":85671331,
     "wof:placetype":"county",

--- a/data/110/875/980/5/1108759805.geojson
+++ b/data/110/875/980/5/1108759805.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.120874,
-    "geom:area_square_m":1482768019.464963,
+    "geom:area_square_m":1482768191.999594,
     "geom:bbox":"-2.126603,6.865719,-1.633822,7.476365",
     "geom:latitude":7.22302,
     "geom:longitude":-1.82568,
@@ -87,9 +87,10 @@
         "hasc:id":"GH.AH.OF",
         "wd:id":"Q427664"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481329998,
-    "wof:geomhash":"e38875ae393e6fe9ad2066ff0a2a6416",
+    "wof:geomhash":"0e622d95ac4c33be68dab9ea2aa0ae19",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -99,7 +100,7 @@
         }
     ],
     "wof:id":1108759805,
-    "wof:lastmodified":1690921678,
+    "wof:lastmodified":1695886309,
     "wof:name":"Offinso",
     "wof:parent_id":85671331,
     "wof:placetype":"county",

--- a/data/110/875/980/7/1108759807.geojson
+++ b/data/110/875/980/7/1108759807.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.3562,
-    "geom:area_square_m":4370184768.155759,
+    "geom:area_square_m":4370184243.714498,
     "geom:bbox":"-1.436561,6.709111,-0.242308,7.541114",
     "geom:latitude":7.152621,
     "geom:longitude":-0.811979,
@@ -105,9 +105,10 @@
         "hasc:id":"GH.AH.SE",
         "wd:id":"Q745202"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481329999,
-    "wof:geomhash":"4b52a44bb2fdca465f02621b6fc6ad6f",
+    "wof:geomhash":"a7aabc5d5ca8902b656c44b2570066d1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -117,7 +118,7 @@
         }
     ],
     "wof:id":1108759807,
-    "wof:lastmodified":1690921677,
+    "wof:lastmodified":1695886309,
     "wof:name":"Sekyere East",
     "wof:parent_id":85671331,
     "wof:placetype":"county",

--- a/data/110/875/980/9/1108759809.geojson
+++ b/data/110/875/980/9/1108759809.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.194872,
-    "geom:area_square_m":2390481690.371246,
+    "geom:area_square_m":2390481470.850238,
     "geom:bbox":"-1.543229,6.91566,-0.899502,7.524546",
     "geom:latitude":7.226175,
     "geom:longitude":-1.217579,
@@ -99,9 +99,10 @@
         "hasc:id":"GH.AH.SW",
         "wd:id":"Q1785381"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330001,
-    "wof:geomhash":"8256f8d81f1ebace63425844d9783cbc",
+    "wof:geomhash":"76b90ee9d47daf328dc0087536b8b9d8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":1108759809,
-    "wof:lastmodified":1690921677,
+    "wof:lastmodified":1695886309,
     "wof:name":"Sekyere West",
     "wof:parent_id":85671331,
     "wof:placetype":"county",

--- a/data/110/875/981/1/1108759811.geojson
+++ b/data/110/875/981/1/1108759811.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.181292,
-    "geom:area_square_m":2226283429.417366,
+    "geom:area_square_m":2226283507.356987,
     "geom:bbox":"-2.866421,6.363657,-2.385535,6.999956",
     "geom:latitude":6.724748,
     "geom:longitude":-2.62762,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"GH.BA.AN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330002,
-    "wof:geomhash":"2f674f0ba9c1337239e3c988d562d96e",
+    "wof:geomhash":"1dbd237ebe28d8e620882e1b00fc1028",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108759811,
-    "wof:lastmodified":1627522153,
+    "wof:lastmodified":1695886622,
     "wof:name":"Asunafo",
     "wof:parent_id":85671337,
     "wof:placetype":"county",

--- a/data/110/875/981/3/1108759813.geojson
+++ b/data/110/875/981/3/1108759813.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.138965,
-    "geom:area_square_m":1705650055.942134,
+    "geom:area_square_m":1705650055.942128,
     "geom:bbox":"-2.79642546857,6.65102893774,-2.22693987986,7.18307027375",
     "geom:latitude":6.962326,
     "geom:longitude":-2.46256,
@@ -93,9 +93,10 @@
         "hasc:id":"GH.BA.AT",
         "wd:id":"Q752527"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330003,
-    "wof:geomhash":"c3a62a967bf487fc111a702dc1f005d5",
+    "wof:geomhash":"8f3dbc208e24dd0f1495e901795bfabc",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1108759813,
-    "wof:lastmodified":1566638262,
+    "wof:lastmodified":1695886310,
     "wof:name":"Asutifi",
     "wof:parent_id":85671337,
     "wof:placetype":"county",

--- a/data/110/875/981/7/1108759817.geojson
+++ b/data/110/875/981/7/1108759817.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.425288,
-    "geom:area_square_m":5208580468.219824,
+    "geom:area_square_m":5208580279.808921,
     "geom:bbox":"-1.433428,7.461623,-0.563784,8.391645",
     "geom:latitude":7.918426,
     "geom:longitude":-1.066073,
@@ -74,9 +74,10 @@
     "wof:concordances":{
         "hasc:id":"GH.BA.AB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330004,
-    "wof:geomhash":"f20e49ae049ba3174f1cc7885cfc05f9",
+    "wof:geomhash":"63940c939f9e468ccc4aa87e87f630be",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1108759817,
-    "wof:lastmodified":1627522153,
+    "wof:lastmodified":1695886622,
     "wof:name":"Atebubu",
     "wof:parent_id":85671337,
     "wof:placetype":"county",

--- a/data/110/875/981/9/1108759819.geojson
+++ b/data/110/875/981/9/1108759819.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.087697,
-    "geom:area_square_m":1075121236.994555,
+    "geom:area_square_m":1075121043.940191,
     "geom:bbox":"-2.861971,7.297586,-2.423966,7.679834",
     "geom:latitude":7.495984,
     "geom:longitude":-2.626169,
@@ -126,9 +126,10 @@
         "hasc:id":"GH.BA.BE",
         "wd:id":"Q261596"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330005,
-    "wof:geomhash":"88be96598ecad511bdaabce40f45efaa",
+    "wof:geomhash":"e14f6fd8c9f6dcf7df597b4e98867aa6",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -138,7 +139,7 @@
         }
     ],
     "wof:id":1108759819,
-    "wof:lastmodified":1690921681,
+    "wof:lastmodified":1695886054,
     "wof:name":"Berekum",
     "wof:parent_id":85671337,
     "wof:placetype":"county",

--- a/data/110/875/982/1/1108759821.geojson
+++ b/data/110/875/982/1/1108759821.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.183632,
-    "geom:area_square_m":2252819889.948977,
+    "geom:area_square_m":2252820432.994364,
     "geom:bbox":"-3.117319,6.846546,-2.407759,7.493904",
     "geom:latitude":7.181726,
     "geom:longitude":-2.813577,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"GH.BA.DO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330006,
-    "wof:geomhash":"b70af511310f8574918a2cd84388857e",
+    "wof:geomhash":"ff815155a21772201f979b13d8a935b2",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108759821,
-    "wof:lastmodified":1627522154,
+    "wof:lastmodified":1695886623,
     "wof:name":"Dormaa",
     "wof:parent_id":85671337,
     "wof:placetype":"county",

--- a/data/110/875/982/3/1108759823.geojson
+++ b/data/110/875/982/3/1108759823.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.127361,
-    "geom:area_square_m":1560372145.356808,
+    "geom:area_square_m":1560372356.009191,
     "geom:bbox":"-2.931157,7.435737,-2.529727,8.164309",
     "geom:latitude":7.773074,
     "geom:longitude":-2.724717,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"GH.BA.JA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330007,
-    "wof:geomhash":"b935c552c358d7e8d31a6a929154bf2a",
+    "wof:geomhash":"aa1869d33d3c57db739d8a4151671e91",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108759823,
-    "wof:lastmodified":1627522155,
+    "wof:lastmodified":1695886624,
     "wof:name":"Jaman",
     "wof:parent_id":85671337,
     "wof:placetype":"county",

--- a/data/110/875/982/5/1108759825.geojson
+++ b/data/110/875/982/5/1108759825.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.534102,
-    "geom:area_square_m":6535486396.919193,
+    "geom:area_square_m":6535486396.919191,
     "geom:bbox":"-2.136281416,7.72734861654,-1.14328770849,8.7599309467",
     "geom:latitude":8.273051,
     "geom:longitude":-1.62376,
@@ -78,9 +78,10 @@
         "hasc:id":"GH.BA.KI",
         "wd:id":"Q695802"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330009,
-    "wof:geomhash":"64009ef800d40b4bf2a85efbe1b01a46",
+    "wof:geomhash":"3d3702c24cb0929a9e14336b5d747c3d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":1108759825,
-    "wof:lastmodified":1566638251,
+    "wof:lastmodified":1695886307,
     "wof:name":"Kintampo",
     "wof:parent_id":85671337,
     "wof:placetype":"county",

--- a/data/110/875/982/7/1108759827.geojson
+++ b/data/110/875/982/7/1108759827.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.205425,
-    "geom:area_square_m":2517690081.578558,
+    "geom:area_square_m":2517690081.578556,
     "geom:bbox":"-1.87491040176,7.33958235717,-1.18068457366,7.88277338313",
     "geom:latitude":7.617811,
     "geom:longitude":-1.603033,
@@ -84,9 +84,10 @@
         "hasc:id":"GH.BA.NK",
         "wd:id":"Q1147881"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330010,
-    "wof:geomhash":"0912237247c216724b62f8df4f1b9dc5",
+    "wof:geomhash":"1343fd7136b62e389aa14c2d4c36ad61",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -96,7 +97,7 @@
         }
     ],
     "wof:id":1108759827,
-    "wof:lastmodified":1566638250,
+    "wof:lastmodified":1695886307,
     "wof:name":"Nkoranza",
     "wof:parent_id":85671337,
     "wof:placetype":"county",

--- a/data/110/875/982/9/1108759829.geojson
+++ b/data/110/875/982/9/1108759829.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.667007,
-    "geom:area_square_m":8174147610.186331,
+    "geom:area_square_m":8174147610.186322,
     "geom:bbox":"-0.923180794782,7.16941671296,0.25615067406,8.19285974704",
     "geom:latitude":7.652057,
     "geom:longitude":-0.339539,
@@ -87,9 +87,10 @@
         "hasc:id":"GH.BA.SE",
         "wd:id":"Q1504064"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330011,
-    "wof:geomhash":"c693663f9aa040d4cb892fa147124fbe",
+    "wof:geomhash":"eaff57f16c62bbafb3f56ca215704892",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -99,7 +100,7 @@
         }
     ],
     "wof:id":1108759829,
-    "wof:lastmodified":1566638250,
+    "wof:lastmodified":1695886307,
     "wof:name":"Sene",
     "wof:parent_id":85671337,
     "wof:placetype":"county",

--- a/data/110/875/983/1/1108759831.geojson
+++ b/data/110/875/983/1/1108759831.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.110497,
-    "geom:area_square_m":1355019949.552299,
+    "geom:area_square_m":1355019964.058679,
     "geom:bbox":"-2.525694,7.123179,-2.131126,7.606522",
     "geom:latitude":7.37072,
     "geom:longitude":-2.350001,
@@ -96,9 +96,10 @@
         "hasc:id":"GH.BA.SY",
         "wd:id":"Q1786388"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330012,
-    "wof:geomhash":"d930ed247fc75606d3ea5184894985a6",
+    "wof:geomhash":"244780e93a12020e9b2932a0d9226f3a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1108759831,
-    "wof:lastmodified":1636502230,
+    "wof:lastmodified":1695886054,
     "wof:name":"Sunyani",
     "wof:parent_id":85671337,
     "wof:placetype":"county",

--- a/data/110/875/983/5/1108759835.geojson
+++ b/data/110/875/983/5/1108759835.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.099889,
-    "geom:area_square_m":1225440022.70426,
+    "geom:area_square_m":1225440022.704259,
     "geom:bbox":"-2.31103958517,7.01504914895,-1.84984279149,7.4181475543",
     "geom:latitude":7.188629,
     "geom:longitude":-2.097855,
@@ -86,9 +86,10 @@
     "wof:concordances":{
         "hasc:id":"GH.BA.TA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330014,
-    "wof:geomhash":"39da4043407d51dac97951a823d7305f",
+    "wof:geomhash":"3d21b0a816f79de07554c1014ed97944",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":1108759835,
-    "wof:lastmodified":1566638245,
+    "wof:lastmodified":1695886305,
     "wof:name":"Tano",
     "wof:parent_id":85671337,
     "wof:placetype":"county",

--- a/data/110/875/983/7/1108759837.geojson
+++ b/data/110/875/983/7/1108759837.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.097593,
-    "geom:area_square_m":1196014757.616518,
+    "geom:area_square_m":1196014757.61653,
     "geom:bbox":"-2.12357132987,7.44327220805,-1.81418293582,7.91953918603",
     "geom:latitude":7.649291,
     "geom:longitude":-1.971436,
@@ -101,9 +101,10 @@
     "wof:concordances":{
         "hasc:id":"GH.BA.TE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330015,
-    "wof:geomhash":"de512e19a1095bac613ce93ba6b9d8fd",
+    "wof:geomhash":"3bfea92269e479cf44f7806e784fabcc",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1108759837,
-    "wof:lastmodified":1566638245,
+    "wof:lastmodified":1695886306,
     "wof:name":"Techiman",
     "wof:parent_id":85671337,
     "wof:placetype":"county",

--- a/data/110/875/983/9/1108759839.geojson
+++ b/data/110/875/983/9/1108759839.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.402124,
-    "geom:area_square_m":4924168760.32023,
+    "geom:area_square_m":4924168769.685666,
     "geom:bbox":"-2.602479,7.417361,-1.970653,8.750051",
     "geom:latitude":7.976782,
     "geom:longitude":-2.331096,
@@ -87,9 +87,10 @@
         "hasc:id":"GH.BA.WE",
         "wd:id":"Q1504094"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330016,
-    "wof:geomhash":"223951a41400365a7ed58df7c6981da2",
+    "wof:geomhash":"0b803cc8ac015973fda9bda8bd0c5c37",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -99,7 +100,7 @@
         }
     ],
     "wof:id":1108759839,
-    "wof:lastmodified":1690921666,
+    "wof:lastmodified":1695886306,
     "wof:name":"Wenchi",
     "wof:parent_id":85671337,
     "wof:placetype":"county",

--- a/data/110/875/984/1/1108759841.geojson
+++ b/data/110/875/984/1/1108759841.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.032268,
-    "geom:area_square_m":397306727.127828,
+    "geom:area_square_m":397306933.775378,
     "geom:bbox":"-1.309095,5.118811,-1.063911,5.400782",
     "geom:latitude":5.272435,
     "geom:longitude":-1.202295,
@@ -99,9 +99,10 @@
         "hasc:id":"GH.CP.AB",
         "wd:id":"Q746494"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330017,
-    "wof:geomhash":"421e484cf0f5574a754cf7105539e1b6",
+    "wof:geomhash":"947409e4d74d571c4a14ff1fa9106c0b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":1108759841,
-    "wof:lastmodified":1690921667,
+    "wof:lastmodified":1695886306,
     "wof:name":"Abura Dunkwa",
     "wof:parent_id":85671341,
     "wof:placetype":"county",

--- a/data/110/875/984/3/1108759843.geojson
+++ b/data/110/875/984/3/1108759843.geojson
@@ -81,9 +81,10 @@
         "hasc:id":"GH.CP.AG",
         "wd:id":"Q395263"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330018,
-    "wof:geomhash":"8bf09065340c435522eef7664ce31ffd",
+    "wof:geomhash":"3ff1338099f00f251904956072ea1e6e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1108759843,
-    "wof:lastmodified":1566638246,
+    "wof:lastmodified":1695886306,
     "wof:name":"Agona",
     "wof:parent_id":85671341,
     "wof:placetype":"county",

--- a/data/110/875/984/5/1108759845.geojson
+++ b/data/110/875/984/5/1108759845.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.041504,
-    "geom:area_square_m":510908429.241969,
+    "geom:area_square_m":510908327.182613,
     "geom:bbox":"-1.100754,5.299662,-0.855307,5.552835",
     "geom:latitude":5.421396,
     "geom:longitude":-0.971794,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"GH.CP.AJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330019,
-    "wof:geomhash":"0858aa21a52e86ce0c687c3e15b463b9",
+    "wof:geomhash":"5c256071bf9f553f6371989b67a4f02a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108759845,
-    "wof:lastmodified":1627522153,
+    "wof:lastmodified":1695886622,
     "wof:name":"Ajumako Enyan Esiam",
     "wof:parent_id":85671341,
     "wof:placetype":"county",

--- a/data/110/875/984/7/1108759847.geojson
+++ b/data/110/875/984/7/1108759847.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.061468,
-    "geom:area_square_m":756380346.449756,
+    "geom:area_square_m":756380203.167873,
     "geom:bbox":"-1.148603,5.49297,-0.85822,5.760994",
     "geom:latitude":5.641449,
     "geom:longitude":-1.010083,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"GH.CP.AO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330020,
-    "wof:geomhash":"419766b0d9f5b94388ac5d4beda2663e",
+    "wof:geomhash":"4077894f2924ce0221830c871f356857",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108759847,
-    "wof:lastmodified":1627522153,
+    "wof:lastmodified":1695886622,
     "wof:name":"Asikuma Odoben Brakwa",
     "wof:parent_id":85671341,
     "wof:placetype":"county",

--- a/data/110/875/984/9/1108759849.geojson
+++ b/data/110/875/984/9/1108759849.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.191702,
-    "geom:area_square_m":2358850160.499937,
+    "geom:area_square_m":2358849990.446726,
     "geom:bbox":"-1.607353,5.34019,-1.05493,5.948663",
     "geom:latitude":5.663592,
     "geom:longitude":-1.315893,
@@ -74,9 +74,10 @@
     "wof:concordances":{
         "hasc:id":"GH.CP.AS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330021,
-    "wof:geomhash":"2c3f3e865323c4954ce6deda63da2953",
+    "wof:geomhash":"a0bff3432b44d087873fea86221bf757",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1108759849,
-    "wof:lastmodified":1627522153,
+    "wof:lastmodified":1695886622,
     "wof:name":"Assin",
     "wof:parent_id":85671341,
     "wof:placetype":"county",

--- a/data/110/875/985/3/1108759853.geojson
+++ b/data/110/875/985/3/1108759853.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.060585,
-    "geom:area_square_m":745643941.454371,
+    "geom:area_square_m":745644371.716222,
     "geom:bbox":"-0.667366,5.321278,-0.366651,5.726772",
     "geom:latitude":5.53666,
     "geom:longitude":-0.514216,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"GH.CP.AE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330023,
-    "wof:geomhash":"40427cf54e36dc9cdc9dd1037c537f05",
+    "wof:geomhash":"f272ce2ca1c8a474eb1a0f5fc4cdcdbf",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108759853,
-    "wof:lastmodified":1627522154,
+    "wof:lastmodified":1695886623,
     "wof:name":"Awutu Efutu Senya",
     "wof:parent_id":85671341,
     "wof:placetype":"county",

--- a/data/110/875/985/5/1108759855.geojson
+++ b/data/110/875/985/5/1108759855.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010016,
-    "geom:area_square_m":123343458.75839,
+    "geom:area_square_m":123343568.792988,
     "geom:bbox":"-1.364485,5.095379,-1.212424,5.24801",
     "geom:latitude":5.164197,
     "geom:longitude":-1.291175,
@@ -158,9 +158,10 @@
     "wof:concordances":{
         "hasc:id":"GH.CP.CC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330024,
-    "wof:geomhash":"01953ac32ad3c98cb6f6bc0e7ef6501c",
+    "wof:geomhash":"551fd9cbe11684b4a6b40d6dbf13b204",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -170,7 +171,7 @@
         }
     ],
     "wof:id":1108759855,
-    "wof:lastmodified":1636502230,
+    "wof:lastmodified":1695886054,
     "wof:name":"Cape Coast",
     "wof:parent_id":85671341,
     "wof:placetype":"county",

--- a/data/110/875/985/7/1108759857.geojson
+++ b/data/110/875/985/7/1108759857.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.066913,
-    "geom:area_square_m":823699798.661485,
+    "geom:area_square_m":823699798.661484,
     "geom:bbox":"-0.913999835375,5.22262151591,-0.554206397597,5.58476488596",
     "geom:latitude":5.41905,
     "geom:longitude":-0.739964,
@@ -78,9 +78,10 @@
         "hasc:id":"GH.CP.GO",
         "wd:id":"Q688675"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330025,
-    "wof:geomhash":"92b0eb03076b5980acbab57c790d047c",
+    "wof:geomhash":"4f0a8c34f9ed9e8056d770cec0ab8ca1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":1108759857,
-    "wof:lastmodified":1566638249,
+    "wof:lastmodified":1695886307,
     "wof:name":"Gomoa",
     "wof:parent_id":85671341,
     "wof:placetype":"county",

--- a/data/110/875/985/9/1108759859.geojson
+++ b/data/110/875/985/9/1108759859.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.038468,
-    "geom:area_square_m":473757509.399891,
+    "geom:area_square_m":473757719.677543,
     "geom:bbox":"-1.573847,5.030416,-1.300465,5.257501",
     "geom:latitude":5.137287,
     "geom:longitude":-1.44322,
@@ -102,9 +102,10 @@
         "hasc:id":"GH.CP.KE",
         "wd:id":"Q1502262"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330026,
-    "wof:geomhash":"2b1c32ff4b3477efbecf171adcd7c995",
+    "wof:geomhash":"63c145ddeecccb9a8b44c8ca48a9f5cc",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -114,7 +115,7 @@
         }
     ],
     "wof:id":1108759859,
-    "wof:lastmodified":1690921671,
+    "wof:lastmodified":1695886307,
     "wof:name":"Komenda/ Edina/ Eguafo",
     "wof:parent_id":85671341,
     "wof:placetype":"county",

--- a/data/110/875/986/1/1108759861.geojson
+++ b/data/110/875/986/1/1108759861.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.042651,
-    "geom:area_square_m":525167106.218847,
+    "geom:area_square_m":525167106.218848,
     "geom:bbox":"-1.21371742666,5.137888908,-0.798667050767,5.41642797968",
     "geom:latitude":5.258779,
     "geom:longitude":-1.012365,
@@ -87,9 +87,10 @@
         "hasc:id":"GH.CP.MF",
         "wd:id":"Q688693"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330027,
-    "wof:geomhash":"49dc4c43c9f5583aafa3c2208501d7d1",
+    "wof:geomhash":"12eeb7b3e4a18fb1022ac18350d4c255",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -99,7 +100,7 @@
         }
     ],
     "wof:id":1108759861,
-    "wof:lastmodified":1566638262,
+    "wof:lastmodified":1695886310,
     "wof:name":"Mfantsiman",
     "wof:parent_id":85671341,
     "wof:placetype":"county",

--- a/data/110/875/986/3/1108759863.geojson
+++ b/data/110/875/986/3/1108759863.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.115575,
-    "geom:area_square_m":1422476261.18234,
+    "geom:area_square_m":1422476182.493802,
     "geom:bbox":"-1.756638,5.241393,-1.284969,5.818326",
     "geom:latitude":5.520316,
     "geom:longitude":-1.52249,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"GH.CP.LD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330028,
-    "wof:geomhash":"460f54e0d2c1ed418d5762e019b398db",
+    "wof:geomhash":"6cc9e43ab4c2d8e7b72e391d38b0541b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108759863,
-    "wof:lastmodified":1627522156,
+    "wof:lastmodified":1695886625,
     "wof:name":"Twifo Heman/ Lower Denkyira",
     "wof:parent_id":85671341,
     "wof:placetype":"county",

--- a/data/110/875/986/5/1108759865.geojson
+++ b/data/110/875/986/5/1108759865.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.095104,
-    "geom:area_square_m":1169574992.306199,
+    "geom:area_square_m":1169575198.461387,
     "geom:bbox":"-2.16852,5.695462,-1.556233,6.326416",
     "geom:latitude":5.982395,
     "geom:longitude":-1.862232,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"GH.CP.UD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330029,
-    "wof:geomhash":"183a2ec5abb2bb335c0d7a6bcd8700af",
+    "wof:geomhash":"aa84ad96bf04e69627ad93e73ce12e82",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108759865,
-    "wof:lastmodified":1627522156,
+    "wof:lastmodified":1695886625,
     "wof:name":"Upper Denkyira",
     "wof:parent_id":85671341,
     "wof:placetype":"county",

--- a/data/110/875/986/7/1108759867.geojson
+++ b/data/110/875/986/7/1108759867.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.436921,
-    "geom:area_square_m":5363468082.564747,
+    "geom:area_square_m":5363467939.159384,
     "geom:bbox":"-0.735377,6.541386,0.247341,7.203637",
     "geom:latitude":6.899841,
     "geom:longitude":-0.178166,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"GH.EP.AP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330031,
-    "wof:geomhash":"6f0bff8308e806623a3e2289096105b2",
+    "wof:geomhash":"2fabdb0e9b6aba94dcbc82baebe19d60",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108759867,
-    "wof:lastmodified":1627522153,
+    "wof:lastmodified":1695886622,
     "wof:name":"Afram Plains",
     "wof:parent_id":85671343,
     "wof:placetype":"county",

--- a/data/110/875/987/1/1108759871.geojson
+++ b/data/110/875/987/1/1108759871.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.052985,
-    "geom:area_square_m":651586719.57522,
+    "geom:area_square_m":651586896.313778,
     "geom:bbox":"-0.327872,5.853653,0.000875,6.137033",
     "geom:latitude":5.99162,
     "geom:longitude":-0.15956,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"GH.EP.AN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330032,
-    "wof:geomhash":"a733a3bcde93c7825fb885ab1de46875",
+    "wof:geomhash":"b935522e15f94f0c6334bfbb12188b1a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108759871,
-    "wof:lastmodified":1627522153,
+    "wof:lastmodified":1695886622,
     "wof:name":"Akwapim North",
     "wof:parent_id":85671343,
     "wof:placetype":"county",

--- a/data/110/875/987/3/1108759873.geojson
+++ b/data/110/875/987/3/1108759873.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.031113,
-    "geom:area_square_m":382728667.87275,
+    "geom:area_square_m":382728656.615402,
     "geom:bbox":"-0.404834,5.736296,-0.118483,5.922184",
     "geom:latitude":5.830896,
     "geom:longitude":-0.26853,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"GH.EP.AS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330033,
-    "wof:geomhash":"a5023ed263701c7244242982b81ee94f",
+    "wof:geomhash":"946e96eb27365e8dadb3df88ce9b04c0",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108759873,
-    "wof:lastmodified":1627522153,
+    "wof:lastmodified":1695886622,
     "wof:name":"Akwapim South",
     "wof:parent_id":85671343,
     "wof:placetype":"county",

--- a/data/110/875/987/5/1108759875.geojson
+++ b/data/110/875/987/5/1108759875.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.073525,
-    "geom:area_square_m":903525455.459813,
+    "geom:area_square_m":903525543.079771,
     "geom:bbox":"-0.033555,6.119256,0.226648,6.56867",
     "geom:latitude":6.376803,
     "geom:longitude":0.096866,
@@ -111,9 +111,10 @@
         "hasc:id":"GH.EP.AG",
         "wd:id":"Q476705"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330034,
-    "wof:geomhash":"4a783ec1d612754366095fbf97e35f14",
+    "wof:geomhash":"1b5c9e9fd57a45b6781a4d2b78c875d9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -123,7 +124,7 @@
         }
     ],
     "wof:id":1108759875,
-    "wof:lastmodified":1690921677,
+    "wof:lastmodified":1695886309,
     "wof:name":"Asuogyaman",
     "wof:parent_id":85671343,
     "wof:placetype":"county",

--- a/data/110/875/987/7/1108759877.geojson
+++ b/data/110/875/987/7/1108759877.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.10637,
-    "geom:area_square_m":1307528779.90913,
+    "geom:area_square_m":1307529054.844702,
     "geom:bbox":"-1.251194,5.945076,-0.807669,6.549352",
     "geom:latitude":6.224908,
     "geom:longitude":-1.048564,
@@ -102,9 +102,10 @@
         "hasc:id":"GH.EP.BN",
         "wd:id":"Q865426"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330035,
-    "wof:geomhash":"c49bb9d16991f302f0509d3761793e8d",
+    "wof:geomhash":"0ec75b9c59b0b27d3ef83766761edf53",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -114,7 +115,7 @@
         }
     ],
     "wof:id":1108759877,
-    "wof:lastmodified":1690921676,
+    "wof:lastmodified":1695886309,
     "wof:name":"Birim North",
     "wof:parent_id":85671343,
     "wof:placetype":"county",

--- a/data/110/875/987/9/1108759879.geojson
+++ b/data/110/875/987/9/1108759879.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.100664,
-    "geom:area_square_m":1238230236.780379,
+    "geom:area_square_m":1238230083.606893,
     "geom:bbox":"-1.233685,5.705611,-0.686166,6.038893",
     "geom:latitude":5.858435,
     "geom:longitude":-0.957251,
@@ -111,9 +111,10 @@
         "hasc:id":"GH.EP.BS",
         "wd:id":"Q749692"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330036,
-    "wof:geomhash":"d67ad09adbc6c98681d383ceaf1710a8",
+    "wof:geomhash":"ee0c5adc0f0e5112428dd53e9f959dd5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -123,7 +124,7 @@
         }
     ],
     "wof:id":1108759879,
-    "wof:lastmodified":1690921676,
+    "wof:lastmodified":1695886308,
     "wof:name":"Birim South",
     "wof:parent_id":85671343,
     "wof:placetype":"county",

--- a/data/110/875/988/1/1108759881.geojson
+++ b/data/110/875/988/1/1108759881.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.120508,
-    "geom:area_square_m":1481151768.717025,
+    "geom:area_square_m":1481151506.57875,
     "geom:bbox":"-0.880487,6.062268,-0.299452,6.475303",
     "geom:latitude":6.282168,
     "geom:longitude":-0.587492,
@@ -96,9 +96,10 @@
         "hasc:id":"GH.EP.EA",
         "wd:id":"Q2829048"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330038,
-    "wof:geomhash":"b89ce706e43f838c595c636217b3d8d7",
+    "wof:geomhash":"4d4a3a2b160494b5a11e3318d448f9cf",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1108759881,
-    "wof:lastmodified":1690921680,
+    "wof:lastmodified":1695886309,
     "wof:name":"East Akim",
     "wof:parent_id":85671343,
     "wof:placetype":"county",

--- a/data/110/875/988/3/1108759883.geojson
+++ b/data/110/875/988/3/1108759883.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.093994,
-    "geom:area_square_m":1154814890.889863,
+    "geom:area_square_m":1154814890.889864,
     "geom:bbox":"-0.512462350057,6.28699316443,-0.129350838477,6.67921801399",
     "geom:latitude":6.48603,
     "geom:longitude":-0.33249,
@@ -84,9 +84,10 @@
         "hasc:id":"GH.EP.FA",
         "wd:id":"Q3066630"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330039,
-    "wof:geomhash":"2b0d698f9a34fc40a9127601796f00d8",
+    "wof:geomhash":"865e2646bf8f4f485eba59c9b76ca2ec",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -96,7 +97,7 @@
         }
     ],
     "wof:id":1108759883,
-    "wof:lastmodified":1566638260,
+    "wof:lastmodified":1695886310,
     "wof:name":"Fanteakwa",
     "wof:parent_id":85671343,
     "wof:placetype":"county",

--- a/data/110/875/988/5/1108759885.geojson
+++ b/data/110/875/988/5/1108759885.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.105285,
-    "geom:area_square_m":1294348688.595275,
+    "geom:area_square_m":1294348680.102508,
     "geom:bbox":"-1.033362,5.961683,-0.573424,6.41253",
     "geom:latitude":6.159278,
     "geom:longitude":-0.828266,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"GH.EP.KB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330040,
-    "wof:geomhash":"208ed9a47b62372ecc53d58c294fb5d4",
+    "wof:geomhash":"5252984c5ea0c66e2e7dbe9596dff1d8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108759885,
-    "wof:lastmodified":1627522155,
+    "wof:lastmodified":1695886624,
     "wof:name":"Kwaebibirem",
     "wof:parent_id":85671343,
     "wof:placetype":"county",

--- a/data/110/875/988/9/1108759889.geojson
+++ b/data/110/875/988/9/1108759889.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.162396,
-    "geom:area_square_m":1994643538.11039,
+    "geom:area_square_m":1994643329.222153,
     "geom:bbox":"-0.9722,6.398177,-0.362886,6.869476",
     "geom:latitude":6.625628,
     "geom:longitude":-0.687821,
@@ -96,9 +96,10 @@
         "hasc:id":"GH.EP.KS",
         "wd:id":"Q1433167"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330042,
-    "wof:geomhash":"c7bdc9c027b8016328a89f7717b9c4a0",
+    "wof:geomhash":"2ee403b0a3eca520e432a58ff3fc0ba1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1108759889,
-    "wof:lastmodified":1690921680,
+    "wof:lastmodified":1695886310,
     "wof:name":"Kwahu South",
     "wof:parent_id":85671343,
     "wof:placetype":"county",

--- a/data/110/875/989/1/1108759891.geojson
+++ b/data/110/875/989/1/1108759891.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.071559,
-    "geom:area_square_m":879400599.488366,
+    "geom:area_square_m":879400483.877777,
     "geom:bbox":"-0.264338,6.090164,0.12122,6.571044",
     "geom:latitude":6.355094,
     "geom:longitude":-0.08133,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"GH.EP.MK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330043,
-    "wof:geomhash":"ee1ab2627d2bbfb9903f308b4a740ed8",
+    "wof:geomhash":"9432323c7a5c6b34d9965ce2408ea744",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108759891,
-    "wof:lastmodified":1627522155,
+    "wof:lastmodified":1695886624,
     "wof:name":"Manya Krobo",
     "wof:parent_id":85671343,
     "wof:placetype":"county",

--- a/data/110/875/989/3/1108759893.geojson
+++ b/data/110/875/989/3/1108759893.geojson
@@ -87,9 +87,10 @@
         "hasc:id":"GH.EP.NJ",
         "wd:id":"Q3338893"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330045,
-    "wof:geomhash":"9999f2572800acf61c34727d2bdc2da4",
+    "wof:geomhash":"0b70dff539f7516d7097d58fb8077c0b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -99,7 +100,7 @@
         }
     ],
     "wof:id":1108759893,
-    "wof:lastmodified":1566638260,
+    "wof:lastmodified":1695886310,
     "wof:name":"New Juaben",
     "wof:parent_id":85671343,
     "wof:placetype":"county",

--- a/data/110/875/989/5/1108759895.geojson
+++ b/data/110/875/989/5/1108759895.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.070647,
-    "geom:area_square_m":868799589.520777,
+    "geom:area_square_m":868799942.975918,
     "geom:bbox":"-0.638767,5.840194,-0.276625,6.135825",
     "geom:latitude":5.986207,
     "geom:longitude":-0.449342,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"GH.EP.SK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330046,
-    "wof:geomhash":"f39d27a66d2e8e2f59c253caecec1d3d",
+    "wof:geomhash":"eb75bf647a398a11873a5a8e323ef46c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108759895,
-    "wof:lastmodified":1627522156,
+    "wof:lastmodified":1695886625,
     "wof:name":"Suhum/ Kraboa/ Coaltar",
     "wof:parent_id":85671343,
     "wof:placetype":"county",

--- a/data/110/875/989/7/1108759897.geojson
+++ b/data/110/875/989/7/1108759897.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.069408,
-    "geom:area_square_m":853744025.599153,
+    "geom:area_square_m":853744052.567285,
     "geom:bbox":"-0.825118,5.708159,-0.395138,6.038323",
     "geom:latitude":5.868122,
     "geom:longitude":-0.646194,
@@ -96,9 +96,10 @@
         "hasc:id":"GH.EP.WA",
         "wd:id":"Q1432741"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330047,
-    "wof:geomhash":"0cfdf07c3453cc040e29804c6f97d564",
+    "wof:geomhash":"885859ed7fb9a07892a310473d839ad8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1108759897,
-    "wof:lastmodified":1690921679,
+    "wof:lastmodified":1695886309,
     "wof:name":"West Akim",
     "wof:parent_id":85671343,
     "wof:placetype":"county",

--- a/data/110/875/989/9/1108759899.geojson
+++ b/data/110/875/989/9/1108759899.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.054629,
-    "geom:area_square_m":671560312.563244,
+    "geom:area_square_m":671560295.573642,
     "geom:bbox":"-0.329028,5.997351,0.0571,6.338013",
     "geom:latitude":6.191066,
     "geom:longitude":-0.150061,
@@ -97,9 +97,10 @@
         "hasc:id":"GH.EP.YK",
         "wd:id":"Q3572285"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330048,
-    "wof:geomhash":"78092582f2b64999601b7335d82c7b42",
+    "wof:geomhash":"9a22c953aa5d13da04dcd559c8ffb4f9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":1108759899,
-    "wof:lastmodified":1690921679,
+    "wof:lastmodified":1695886309,
     "wof:name":"Yilo Krobo",
     "wof:parent_id":85671343,
     "wof:placetype":"county",

--- a/data/110/875/990/1/1108759901.geojson
+++ b/data/110/875/990/1/1108759901.geojson
@@ -65,12 +65,13 @@
     "wof:concordances":{
         "hasc:id":"GH.AA.AC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:coterminous":[
         421168965
     ],
     "wof:country":"GH",
     "wof:created":1481330049,
-    "wof:geomhash":"42ef6f7a252ce616a66b1a59c43362ea",
+    "wof:geomhash":"9b594d720afb683470240f4ff1bf52a1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108759901,
-    "wof:lastmodified":1627522154,
+    "wof:lastmodified":1695886623,
     "wof:name":"Accra Metro",
     "wof:parent_id":85671353,
     "wof:placetype":"county",

--- a/data/110/875/990/3/1108759903.geojson
+++ b/data/110/875/990/3/1108759903.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.053706,
-    "geom:area_square_m":660604616.057957,
+    "geom:area_square_m":660604585.476154,
     "geom:bbox":"0.332922,5.758722,0.675417,6.005823",
     "geom:latitude":5.87099,
     "geom:longitude":0.47825,
@@ -96,9 +96,10 @@
         "hasc:id":"GH.AA.DE",
         "wd:id":"Q2304325"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330051,
-    "wof:geomhash":"768b6408d4372602d9f1a7a4b8bcf7e7",
+    "wof:geomhash":"a5163943e3ea40c1a6383022b61aff2a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1108759903,
-    "wof:lastmodified":1690921665,
+    "wof:lastmodified":1695886305,
     "wof:name":"Dangme East",
     "wof:parent_id":85671353,
     "wof:placetype":"county",

--- a/data/110/875/990/7/1108759907.geojson
+++ b/data/110/875/990/7/1108759907.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.133569,
-    "geom:area_square_m":1642809864.266237,
+    "geom:area_square_m":1642810028.549654,
     "geom:bbox":"-0.11682,5.689384,0.427044,6.126875",
     "geom:latitude":5.916637,
     "geom:longitude":0.152559,
@@ -103,9 +103,10 @@
         "hasc:id":"GH.AA.DW",
         "wd:id":"Q2304316"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330052,
-    "wof:geomhash":"17330a66c8b5382d76ec84ca435bc695",
+    "wof:geomhash":"392627cd485a2913a8dcea1159284809",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -115,7 +116,7 @@
         }
     ],
     "wof:id":1108759907,
-    "wof:lastmodified":1690921664,
+    "wof:lastmodified":1695886305,
     "wof:name":"Dangme West",
     "wof:parent_id":85671353,
     "wof:placetype":"county",

--- a/data/110/875/990/9/1108759909.geojson
+++ b/data/110/875/990/9/1108759909.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.061234,
-    "geom:area_square_m":753444226.530794,
+    "geom:area_square_m":753443952.14194,
     "geom:bbox":"-0.494539,5.494181,-0.138526,5.824605",
     "geom:latitude":5.681976,
     "geom:longitude":-0.336065,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"GH.AA.GA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330053,
-    "wof:geomhash":"83e72396cc54ab08c2ccb18ecc720f1c",
+    "wof:geomhash":"382b7c98ac2ff0604bc9166cdc061f45",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108759909,
-    "wof:lastmodified":1627522154,
+    "wof:lastmodified":1695886623,
     "wof:name":"Ga",
     "wof:parent_id":85671353,
     "wof:placetype":"county",

--- a/data/110/875/991/1/1108759911.geojson
+++ b/data/110/875/991/1/1108759911.geojson
@@ -152,9 +152,10 @@
     "wof:concordances":{
         "hasc:id":"GH.AA.TE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330054,
-    "wof:geomhash":"8904f225f51f0c98c2373d1ee9afaf7c",
+    "wof:geomhash":"c8d4c4d1eab85855783aa35a58bc82d5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -164,7 +165,7 @@
         }
     ],
     "wof:id":1108759911,
-    "wof:lastmodified":1566638239,
+    "wof:lastmodified":1695886304,
     "wof:name":"Tema",
     "wof:parent_id":85671353,
     "wof:placetype":"county",

--- a/data/110/875/991/3/1108759913.geojson
+++ b/data/110/875/991/3/1108759913.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.829501,
-    "geom:area_square_m":10128737552.837978,
+    "geom:area_square_m":10128737552.837954,
     "geom:bbox":"-2.78023,8.14864817308,-1.74765933274,9.82405673869",
     "geom:latitude":9.055778,
     "geom:longitude":-2.302128,
@@ -86,9 +86,10 @@
     "wof:concordances":{
         "hasc:id":"GH.NP.BO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330055,
-    "wof:geomhash":"76dcfff2dfec3993095490938f87621a",
+    "wof:geomhash":"288ecc7c6f404c1ae35f58c07f48cd85",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":1108759913,
-    "wof:lastmodified":1566638239,
+    "wof:lastmodified":1695886304,
     "wof:name":"Bole",
     "wof:parent_id":85671319,
     "wof:placetype":"county",

--- a/data/110/875/991/5/1108759915.geojson
+++ b/data/110/875/991/5/1108759915.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.355082,
-    "geom:area_square_m":4331532916.097915,
+    "geom:area_square_m":4331532741.099056,
     "geom:bbox":"-0.659837,9.065183,0.258411,9.79455",
     "geom:latitude":9.412292,
     "geom:longitude":-0.187828,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"GH.NP.YE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330057,
-    "wof:geomhash":"00f2b61ea6aa62fecf01acc94a24a444",
+    "wof:geomhash":"95c99755facba3e88a4110e031d40029",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108759915,
-    "wof:lastmodified":1627522154,
+    "wof:lastmodified":1695886623,
     "wof:name":"East Dagomba",
     "wof:parent_id":85671319,
     "wof:placetype":"county",

--- a/data/110/875/991/7/1108759917.geojson
+++ b/data/110/875/991/7/1108759917.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.236471,
-    "geom:area_square_m":2875423274.600525,
+    "geom:area_square_m":2875423809.074105,
     "geom:bbox":"-0.669934,10.241714,0.197466,10.707606",
     "geom:latitude":10.458808,
     "geom:longitude":-0.235639,
@@ -109,9 +109,10 @@
         "hasc:id":"GH.NP.EM",
         "wd:id":"Q824725"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330058,
-    "wof:geomhash":"08b38564efc2c870a71ce7108d0f8865",
+    "wof:geomhash":"c4d12070b0e97d85f90d13ec90f6c1d8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -121,7 +122,7 @@
         }
     ],
     "wof:id":1108759917,
-    "wof:lastmodified":1690921662,
+    "wof:lastmodified":1695886304,
     "wof:name":"East Mamprusi",
     "wof:parent_id":85671319,
     "wof:placetype":"county",

--- a/data/110/875/991/9/1108759919.geojson
+++ b/data/110/875/991/9/1108759919.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.824479,
-    "geom:area_square_m":10079774497.291079,
+    "geom:area_square_m":10079773684.979136,
     "geom:bbox":"-1.253674,7.96566,0.220381,9.310049",
     "geom:latitude":8.610556,
     "geom:longitude":-0.601277,
@@ -109,9 +109,10 @@
         "hasc:id":"GH.NP.EG",
         "wd:id":"Q825097"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330059,
-    "wof:geomhash":"0b071d33370c0a442bc568420c55280b",
+    "wof:geomhash":"fc798415c816f1e676525a534939523e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -121,7 +122,7 @@
         }
     ],
     "wof:id":1108759919,
-    "wof:lastmodified":1690921661,
+    "wof:lastmodified":1695886303,
     "wof:name":"Gonja East",
     "wof:parent_id":85671319,
     "wof:placetype":"county",

--- a/data/110/875/992/1/1108759921.geojson
+++ b/data/110/875/992/1/1108759921.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.437418,
-    "geom:area_square_m":17543743353.934296,
+    "geom:area_square_m":17543743661.05508,
     "geom:bbox":"-2.221277,8.540148,-0.718326,10.103303",
     "geom:latitude":9.224396,
     "geom:longitude":-1.52315,
@@ -103,9 +103,10 @@
         "hasc:id":"GH.NP.WG",
         "wd:id":"Q3110546"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330061,
-    "wof:geomhash":"3d794ac137bb8cc04320cfe7c4a41dd9",
+    "wof:geomhash":"aaac63e000cab165c739d5a5a9526fff",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -115,7 +116,7 @@
         }
     ],
     "wof:id":1108759921,
-    "wof:lastmodified":1690921674,
+    "wof:lastmodified":1695886308,
     "wof:name":"Gonja West",
     "wof:parent_id":85671319,
     "wof:placetype":"county",

--- a/data/110/875/992/5/1108759925.geojson
+++ b/data/110/875/992/5/1108759925.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.476854,
-    "geom:area_square_m":5807277567.320209,
+    "geom:area_square_m":5807277224.405447,
     "geom:bbox":"-0.762451,9.532549,0.123412,10.36232",
     "geom:latitude":9.972166,
     "geom:longitude":-0.328122,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"GH.NP.GK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330062,
-    "wof:geomhash":"47dc34a7f5dd7635ed85b2264846deb8",
+    "wof:geomhash":"cc3e9bcde4df701c47eb6fdb573e89d1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108759925,
-    "wof:lastmodified":1627522154,
+    "wof:lastmodified":1695886624,
     "wof:name":"Gushiegu/ Karaga",
     "wof:parent_id":85671319,
     "wof:placetype":"county",

--- a/data/110/875/992/7/1108759927.geojson
+++ b/data/110/875/992/7/1108759927.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.328832,
-    "geom:area_square_m":4017860438.727248,
+    "geom:area_square_m":4017860698.953727,
     "geom:bbox":"-0.489485,8.502986,0.370776,9.215573",
     "geom:latitude":8.829957,
     "geom:longitude":-0.039667,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"GH.NP.NA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330064,
-    "wof:geomhash":"034a734e2a3bc7b6ac6ab6501169ef14",
+    "wof:geomhash":"1c2d63023d07017f025312a8ef12e2f2",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108759927,
-    "wof:lastmodified":1627522156,
+    "wof:lastmodified":1695886625,
     "wof:name":"Nanumba",
     "wof:parent_id":85671319,
     "wof:placetype":"county",

--- a/data/110/875/992/9/1108759929.geojson
+++ b/data/110/875/992/9/1108759929.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.268095,
-    "geom:area_square_m":3265446581.062647,
+    "geom:area_square_m":3265447188.882633,
     "geom:bbox":"-0.052966,9.371845,0.41752,10.426816",
     "geom:latitude":9.920826,
     "geom:longitude":0.205591,
@@ -114,9 +114,10 @@
         "hasc:id":"GH.NP.SC",
         "wd:id":"Q3460648"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330065,
-    "wof:geomhash":"b36d609e6ea6fb1cdd1e64aef5ba8168",
+    "wof:geomhash":"c0f8bd15f5dd794027f8b9c6a77a0f6a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":1108759929,
-    "wof:lastmodified":1690921674,
+    "wof:lastmodified":1695886308,
     "wof:name":"Saboba/ Chereponi",
     "wof:parent_id":85671319,
     "wof:placetype":"county",

--- a/data/110/875/993/1/1108759931.geojson
+++ b/data/110/875/993/1/1108759931.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.177176,
-    "geom:area_square_m":2158877036.964023,
+    "geom:area_square_m":2158877037.426194,
     "geom:bbox":"-1.027579,9.459325,-0.599272,10.183741",
     "geom:latitude":9.792865,
     "geom:longitude":-0.803259,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"GH.NP.SN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330066,
-    "wof:geomhash":"5ff305e1bcc4cc59f356a5ab6feb2bca",
+    "wof:geomhash":"597bd9303679fc17ae40823ad3bda01b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108759931,
-    "wof:lastmodified":1627522156,
+    "wof:lastmodified":1695886626,
     "wof:name":"Savelugu/ Nanton",
     "wof:parent_id":85671319,
     "wof:placetype":"county",

--- a/data/110/875/993/3/1108759933.geojson
+++ b/data/110/875/993/3/1108759933.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.058375,
-    "geom:area_square_m":712112604.540141,
+    "geom:area_square_m":712112604.540142,
     "geom:bbox":"-0.940877892306,9.29853131273,-0.633935523648,9.55197473978",
     "geom:latitude":9.406479,
     "geom:longitude":-0.800572,
@@ -143,9 +143,10 @@
     "wof:concordances":{
         "hasc:id":"GH.NP.TA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330067,
-    "wof:geomhash":"b9ec1bc63416bab2254a61e84828b796",
+    "wof:geomhash":"0317080981edfb71ae7c83f3e93d736e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -155,7 +156,7 @@
         }
     ],
     "wof:id":1108759933,
-    "wof:lastmodified":1566638255,
+    "wof:lastmodified":1695886308,
     "wof:name":"Tamale",
     "wof:parent_id":85671319,
     "wof:placetype":"county",

--- a/data/110/875/993/5/1108759935.geojson
+++ b/data/110/875/993/5/1108759935.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.189974,
-    "geom:area_square_m":2315705359.278851,
+    "geom:area_square_m":2315705467.975378,
     "geom:bbox":"-1.328965,9.316695,-0.896686,10.094298",
     "geom:latitude":9.66581,
     "geom:longitude":-1.106067,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"GH.NP.TK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330068,
-    "wof:geomhash":"506c99929815be589dd074846e3a0071",
+    "wof:geomhash":"1eead24f529f7ee1210f1bfd2781f71b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108759935,
-    "wof:lastmodified":1627522156,
+    "wof:lastmodified":1695886626,
     "wof:name":"Tolon/ Kumbungu",
     "wof:parent_id":85671319,
     "wof:placetype":"county",

--- a/data/110/875/993/7/1108759937.geojson
+++ b/data/110/875/993/7/1108759937.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.376848,
-    "geom:area_square_m":4584975961.881622,
+    "geom:area_square_m":4584975972.246509,
     "geom:bbox":"-1.660359,9.932581,-0.561706,10.637168",
     "geom:latitude":10.280773,
     "geom:longitude":-1.070202,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"GH.NP.WM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330070,
-    "wof:geomhash":"6135d07a4d2f890956c21f7a3efbc8f4",
+    "wof:geomhash":"55b846b3a10fefa237bb872b095877ab",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108759937,
-    "wof:lastmodified":1627522155,
+    "wof:lastmodified":1695886624,
     "wof:name":"West Mamprusi",
     "wof:parent_id":85671319,
     "wof:placetype":"county",

--- a/data/110/875/993/9/1108759939.geojson
+++ b/data/110/875/993/9/1108759939.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.181316,
-    "geom:area_square_m":2213348249.975391,
+    "geom:area_square_m":2213348680.075601,
     "geom:bbox":"0.166615,8.769354,0.566955,9.500684",
     "geom:latitude":9.169668,
     "geom:longitude":0.374748,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"GH.NP.ZT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330071,
-    "wof:geomhash":"323b3d60746cc52f07ab471692fba8c7",
+    "wof:geomhash":"346185bf9cd081134709d8102373a7e5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108759939,
-    "wof:lastmodified":1627522157,
+    "wof:lastmodified":1695886626,
     "wof:name":"Zabzugu/ Tatale",
     "wof:parent_id":85671319,
     "wof:placetype":"county",

--- a/data/110/875/994/3/1108759943.geojson
+++ b/data/110/875/994/3/1108759943.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.162261,
-    "geom:area_square_m":1970174311.929201,
+    "geom:area_square_m":1970174754.475909,
     "geom:bbox":"-0.39436,10.607791,0.034421,11.166667",
     "geom:latitude":10.901132,
     "geom:longitude":-0.200198,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"GH.UE.BE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330072,
-    "wof:geomhash":"345377b06057a1315bc9f7a37efe7245",
+    "wof:geomhash":"caa47099ff46ddc901c4ea31503d2ef1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108759943,
-    "wof:lastmodified":1627522154,
+    "wof:lastmodified":1695886624,
     "wof:name":"Bawku East",
     "wof:parent_id":85671323,
     "wof:placetype":"county",

--- a/data/110/875/994/5/1108759945.geojson
+++ b/data/110/875/994/5/1108759945.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.08898,
-    "geom:area_square_m":1080684267.720623,
+    "geom:area_square_m":1080683949.370333,
     "geom:bbox":"-0.618456,10.57276,-0.329909,11.108611",
     "geom:latitude":10.821635,
     "geom:longitude":-0.465068,
@@ -102,9 +102,10 @@
         "hasc:id":"GH.UE.BW",
         "wd:id":"Q812034"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330073,
-    "wof:geomhash":"95ca0d23f31747f1dc4379db611a6524",
+    "wof:geomhash":"fb24c60a434a1904f185d6440141cad2",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -114,7 +115,7 @@
         }
     ],
     "wof:id":1108759945,
-    "wof:lastmodified":1690921675,
+    "wof:lastmodified":1695886308,
     "wof:name":"Bawku West",
     "wof:parent_id":85671323,
     "wof:placetype":"county",

--- a/data/110/875/994/7/1108759947.geojson
+++ b/data/110/875/994/7/1108759947.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.121888,
-    "geom:area_square_m":1480926713.596677,
+    "geom:area_square_m":1480926684.910563,
     "geom:bbox":"-1.013311,10.510134,-0.522563,10.893322",
     "geom:latitude":10.708327,
     "geom:longitude":-0.759305,
@@ -158,9 +158,10 @@
     "wof:concordances":{
         "hasc:id":"GH.UE.BG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330074,
-    "wof:geomhash":"87b6b30ecb375aeaad9d48436d7859da",
+    "wof:geomhash":"0165658fabe5d0beebe74e412d883b3d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -170,7 +171,7 @@
         }
     ],
     "wof:id":1108759947,
-    "wof:lastmodified":1636502230,
+    "wof:lastmodified":1695886054,
     "wof:name":"Bolgatanga",
     "wof:parent_id":85671323,
     "wof:placetype":"county",

--- a/data/110/875/994/9/1108759949.geojson
+++ b/data/110/875/994/9/1108759949.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.040068,
-    "geom:area_square_m":486476102.47982,
+    "geom:area_square_m":486476357.03713,
     "geom:bbox":"-0.938652,10.827806,-0.612431,11.009167",
     "geom:latitude":10.918261,
     "geom:longitude":-0.785298,
@@ -96,9 +96,10 @@
         "hasc:id":"GH.UE.BO",
         "wd:id":"Q749703"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330076,
-    "wof:geomhash":"24863466e219431264de881f1e3a0485",
+    "wof:geomhash":"f6ce670b9b76563fb2dbba88c1edcd52",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1108759949,
-    "wof:lastmodified":1690921675,
+    "wof:lastmodified":1695886308,
     "wof:name":"Bongo",
     "wof:parent_id":85671323,
     "wof:placetype":"county",

--- a/data/110/875/995/1/1108759951.geojson
+++ b/data/110/875/995/1/1108759951.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.180532,
-    "geom:area_square_m":2194260874.053723,
+    "geom:area_square_m":2194261138.761945,
     "geom:bbox":"-1.591245,10.281437,-1.061201,10.880287",
     "geom:latitude":10.592773,
     "geom:longitude":-1.306121,
@@ -96,9 +96,10 @@
         "hasc:id":"GH.UE.BU",
         "wd:id":"Q1003075"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330077,
-    "wof:geomhash":"ac3bb5b699fe93170136ef0aa7855eb0",
+    "wof:geomhash":"0b2112bc528a8a48de98421e604df40a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1108759951,
-    "wof:lastmodified":1690921673,
+    "wof:lastmodified":1695886307,
     "wof:name":"Builsa",
     "wof:parent_id":85671323,
     "wof:placetype":"county",

--- a/data/110/875/995/3/1108759953.geojson
+++ b/data/110/875/995/3/1108759953.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.146697,
-    "geom:area_square_m":1781573201.657984,
+    "geom:area_square_m":1781573176.807292,
     "geom:bbox":"-1.524838,10.49078,-0.889933,11.02692",
     "geom:latitude":10.839121,
     "geom:longitude":-1.170665,
@@ -87,9 +87,10 @@
         "hasc:id":"GH.UE.KN",
         "wd:id":"Q749266"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330078,
-    "wof:geomhash":"6bdbc625be2ff589e88f05b0b3103b3e",
+    "wof:geomhash":"b3d575f480f8777bab716302bddcdacc",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -99,7 +100,7 @@
         }
     ],
     "wof:id":1108759953,
-    "wof:lastmodified":1690921673,
+    "wof:lastmodified":1695886307,
     "wof:name":"Kasena/ Nankani",
     "wof:parent_id":85671323,
     "wof:placetype":"county",

--- a/data/110/875/995/5/1108759955.geojson
+++ b/data/110/875/995/5/1108759955.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.160135,
-    "geom:area_square_m":1945747486.268648,
+    "geom:area_square_m":1945747392.100867,
     "geom:bbox":"-2.853592,10.419444,-2.320309,11.002222",
     "geom:latitude":10.687563,
     "geom:longitude":-2.599095,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"GH.UW.JL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330079,
-    "wof:geomhash":"be936aed32b9500b95ffb62809aa5512",
+    "wof:geomhash":"b04683380aecd0abfc2edfe8177e14f4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108759955,
-    "wof:lastmodified":1627522155,
+    "wof:lastmodified":1695886625,
     "wof:name":"Jirapa/ Lambussie",
     "wof:parent_id":85671327,
     "wof:placetype":"county",

--- a/data/110/875/995/7/1108759957.geojson
+++ b/data/110/875/995/7/1108759957.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.070338,
-    "geom:area_square_m":854528402.80645,
+    "geom:area_square_m":854528471.97479,
     "geom:bbox":"-2.933057,10.451926,-2.691387,11.00221",
     "geom:latitude":10.733767,
     "geom:longitude":-2.811553,
@@ -96,9 +96,10 @@
         "hasc:id":"GH.UW.LA",
         "wd:id":"Q1506347"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330080,
-    "wof:geomhash":"c701b2bc4aa4dad6f6b5143a6db2ef9c",
+    "wof:geomhash":"533f1f2a6a788f482ac0211575b1f260",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1108759957,
-    "wof:lastmodified":1690921672,
+    "wof:lastmodified":1695886308,
     "wof:name":"Lawra",
     "wof:parent_id":85671327,
     "wof:placetype":"county",

--- a/data/110/875/996/1/1108759961.geojson
+++ b/data/110/875/996/1/1108759961.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.236792,
-    "geom:area_square_m":2880444705.637187,
+    "geom:area_square_m":2880444446.702644,
     "geom:bbox":"-2.844721,10.100573,-1.997796,10.581514",
     "geom:latitude":10.337835,
     "geom:longitude":-2.422019,
@@ -100,9 +100,10 @@
         "hasc:id":"GH.UW.NA",
         "wd:id":"Q1315544"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330081,
-    "wof:geomhash":"0faa80c85798434470444d8fcd4be1e9",
+    "wof:geomhash":"517559c042428460058ecb44a3915b81",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -112,7 +113,7 @@
         }
     ],
     "wof:id":1108759961,
-    "wof:lastmodified":1690921663,
+    "wof:lastmodified":1695886304,
     "wof:name":"Nawdoli",
     "wof:parent_id":85671327,
     "wof:placetype":"county",

--- a/data/110/875/996/3/1108759963.geojson
+++ b/data/110/875/996/3/1108759963.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.582717,
-    "geom:area_square_m":7080290666.049824,
+    "geom:area_square_m":7080290666.049825,
     "geom:bbox":"-2.61204290621,10.1709265003,-1.445152615,11.028334",
     "geom:latitude":10.691161,
     "geom:longitude":-1.931602,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"GH.UW.SS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330083,
-    "wof:geomhash":"bf79bb693975cb02345ae7170cb69516",
+    "wof:geomhash":"063ef366dc43ea36355a74cc12b02fe9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108759963,
-    "wof:lastmodified":1566638240,
+    "wof:lastmodified":1695886304,
     "wof:name":"Sissala",
     "wof:parent_id":85671327,
     "wof:placetype":"county",

--- a/data/110/875/996/5/1108759965.geojson
+++ b/data/110/875/996/5/1108759965.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.496797,
-    "geom:area_square_m":6049784089.825269,
+    "geom:area_square_m":6049784004.51792,
     "geom:bbox":"-2.803333,9.620274,-1.573742,10.362667",
     "geom:latitude":9.992887,
     "geom:longitude":-2.235957,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"GH.UW.WA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330084,
-    "wof:geomhash":"96b7445b1c17554627d01e6b3acd781c",
+    "wof:geomhash":"8adefef6633d0c1ebc647b3c6553cc7e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108759965,
-    "wof:lastmodified":1636502230,
+    "wof:lastmodified":1695886054,
     "wof:name":"Wa",
     "wof:parent_id":85671327,
     "wof:placetype":"county",

--- a/data/110/875/996/7/1108759967.geojson
+++ b/data/110/875/996/7/1108759967.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.139707,
-    "geom:area_square_m":1717459097.296868,
+    "geom:area_square_m":1717458948.933098,
     "geom:bbox":"0.13995,5.97871,0.704306,6.339028",
     "geom:latitude":6.183227,
     "geom:longitude":0.417436,
@@ -87,9 +87,10 @@
         "hasc:id":"GH.TV.NT",
         "wd:id":"Q3531554"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330085,
-    "wof:geomhash":"b673b9ee404d91c0b0c5208597cd58f2",
+    "wof:geomhash":"d3fd1d6cee4f986b5b87ccbf634c4be4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -99,7 +100,7 @@
         }
     ],
     "wof:id":1108759967,
-    "wof:lastmodified":1690921662,
+    "wof:lastmodified":1695886304,
     "wof:name":"Adidome",
     "wof:parent_id":85671357,
     "wof:placetype":"county",

--- a/data/110/875/996/9/1108759969.geojson
+++ b/data/110/875/996/9/1108759969.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.068894,
-    "geom:area_square_m":846873367.603321,
+    "geom:area_square_m":846873367.603317,
     "geom:bbox":"0.658029403378,5.96742526622,0.957060578758,6.44342394287",
     "geom:latitude":6.215615,
     "geom:longitude":0.794874,
@@ -87,9 +87,10 @@
         "hasc:id":"GH.TV.AK",
         "wd:id":"Q1433330"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330086,
-    "wof:geomhash":"1099e594bfcbea69f4f6eec2d7d8a93d",
+    "wof:geomhash":"9fd25ae1b90981e51791e423ddce17ef",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -99,7 +100,7 @@
         }
     ],
     "wof:id":1108759969,
-    "wof:lastmodified":1566638240,
+    "wof:lastmodified":1695886304,
     "wof:name":"Akatsi",
     "wof:parent_id":85671357,
     "wof:placetype":"county",

--- a/data/110/875/997/1/1108759971.geojson
+++ b/data/110/875/997/1/1108759971.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.208475,
-    "geom:area_square_m":2561019335.276718,
+    "geom:area_square_m":2561020005.831599,
     "geom:bbox":"0.2041,6.290078,0.753891,6.94039",
     "geom:latitude":6.54573,
     "geom:longitude":0.493064,
@@ -92,9 +92,10 @@
     "wof:concordances":{
         "hasc:id":"GH.TV.HO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330088,
-    "wof:geomhash":"8157d1577494952e74d59a229f31e5fa",
+    "wof:geomhash":"2a27d7b8ae2a783fd3222e3e7a36394f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1108759971,
-    "wof:lastmodified":1636502230,
+    "wof:lastmodified":1695886054,
     "wof:name":"Ho",
     "wof:parent_id":85671357,
     "wof:placetype":"county",

--- a/data/110/875/997/3/1108759973.geojson
+++ b/data/110/875/997/3/1108759973.geojson
@@ -104,9 +104,10 @@
     "wof:concordances":{
         "hasc:id":"GH.TV.HH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330089,
-    "wof:geomhash":"6f639bcba9fd903c56226abf73ab63a8",
+    "wof:geomhash":"06879f126d39be925a0f496ef7686b70",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1108759973,
-    "wof:lastmodified":1566638242,
+    "wof:lastmodified":1695886305,
     "wof:name":"Hohoe",
     "wof:parent_id":85671357,
     "wof:placetype":"county",

--- a/data/110/875/997/5/1108759975.geojson
+++ b/data/110/875/997/5/1108759975.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.111008,
-    "geom:area_square_m":1361419419.965108,
+    "geom:area_square_m":1361419646.150907,
     "geom:bbox":"0.207568,7.071896,0.658216,7.520379",
     "geom:latitude":7.330411,
     "geom:longitude":0.402089,
@@ -105,9 +105,10 @@
         "hasc:id":"GH.TV.JA",
         "wd:id":"Q1432676"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330091,
-    "wof:geomhash":"8f3f77b5d1f987bdbc9d541cb7136b69",
+    "wof:geomhash":"868a40c3e2f0d50914d7aaade1c20606",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -117,7 +118,7 @@
         }
     ],
     "wof:id":1108759975,
-    "wof:lastmodified":1690921664,
+    "wof:lastmodified":1695886305,
     "wof:name":"Jasikan",
     "wof:parent_id":85671357,
     "wof:placetype":"county",

--- a/data/110/875/997/9/1108759979.geojson
+++ b/data/110/875/997/9/1108759979.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.086528,
-    "geom:area_square_m":1060227467.766052,
+    "geom:area_square_m":1060227779.575821,
     "geom:bbox":"0.30666,7.495452,0.631059,7.976915",
     "geom:latitude":7.723085,
     "geom:longitude":0.491645,
@@ -96,9 +96,10 @@
         "hasc:id":"GH.TV.KJ",
         "wd:id":"Q3191794"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330092,
-    "wof:geomhash":"5d61949f29a681066288a88825bc6515",
+    "wof:geomhash":"aec04aa4d5f14d23bd722a6ac0c355c8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1108759979,
-    "wof:lastmodified":1690921663,
+    "wof:lastmodified":1695886305,
     "wof:name":"Kadjebi",
     "wof:parent_id":85671357,
     "wof:placetype":"county",

--- a/data/110/875/998/1/1108759981.geojson
+++ b/data/110/875/998/1/1108759981.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.072911,
-    "geom:area_square_m":896764152.793423,
+    "geom:area_square_m":896764152.793424,
     "geom:bbox":"0.684106110226,5.762055397,1.05894381235,6.09480045623",
     "geom:latitude":5.907833,
     "geom:longitude":0.863583,
@@ -92,9 +92,10 @@
     "wof:concordances":{
         "hasc:id":"GH.TV.KA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330093,
-    "wof:geomhash":"aef3716145c04ea47e057f900d0bf1cb",
+    "wof:geomhash":"ba0d54e47ba8135ff58297aa4b03898f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1108759981,
-    "wof:lastmodified":1566638237,
+    "wof:lastmodified":1695886303,
     "wof:name":"Keta",
     "wof:parent_id":85671357,
     "wof:placetype":"county",

--- a/data/110/875/998/3/1108759983.geojson
+++ b/data/110/875/998/3/1108759983.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.059793,
-    "geom:area_square_m":735094004.815382,
+    "geom:area_square_m":735094004.815386,
     "geom:bbox":"0.856149776658,6.01345061749,1.19947914281,6.335475",
     "geom:latitude":6.153968,
     "geom:longitude":1.004817,
@@ -78,9 +78,10 @@
         "hasc:id":"GH.TV.KU",
         "wd:id":"Q1432647"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330094,
-    "wof:geomhash":"f13f1dab176ace31503be17c3a53110a",
+    "wof:geomhash":"cdc4174c7196548fd08d0a0c139bad27",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":1108759983,
-    "wof:lastmodified":1566638238,
+    "wof:lastmodified":1695886303,
     "wof:name":"Ketu",
     "wof:parent_id":85671357,
     "wof:placetype":"county",

--- a/data/110/875/998/5/1108759985.geojson
+++ b/data/110/875/998/5/1108759985.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.082687,
-    "geom:area_square_m":1015235766.752481,
+    "geom:area_square_m":1015235666.634588,
     "geom:bbox":"0.127066,6.452562,0.374394,7.107189",
     "geom:latitude":6.802745,
     "geom:longitude":0.247693,
@@ -86,9 +86,10 @@
     "wof:concordances":{
         "hasc:id":"GH.TV.KP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330095,
-    "wof:geomhash":"bbc760b08dc5d354989c885c747a0162",
+    "wof:geomhash":"4eeab344ebe12526abac933309350d9c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":1108759985,
-    "wof:lastmodified":1627522155,
+    "wof:lastmodified":1695886625,
     "wof:name":"Kpandu",
     "wof:parent_id":85671357,
     "wof:placetype":"county",

--- a/data/110/875/998/7/1108759987.geojson
+++ b/data/110/875/998/7/1108759987.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.385701,
-    "geom:area_square_m":4723621706.163713,
+    "geom:area_square_m":4723621706.163718,
     "geom:bbox":"-0.382064411056,7.40978692447,0.481290307525,8.3499025834",
     "geom:latitude":7.930351,
     "geom:longitude":0.11093,
@@ -71,9 +71,10 @@
     "wof:concordances":{
         "hasc:id":"GH.TV.KR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330096,
-    "wof:geomhash":"cf8378ccc505b2b7ca89e6a1bd3f7bf3",
+    "wof:geomhash":"784393cf4539dec455f2264d3af1cc9c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1108759987,
-    "wof:lastmodified":1566638237,
+    "wof:lastmodified":1695886303,
     "wof:name":"Krachi",
     "wof:parent_id":85671357,
     "wof:placetype":"county",

--- a/data/110/875/998/9/1108759989.geojson
+++ b/data/110/875/998/9/1108759989.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.304897,
-    "geom:area_square_m":3729817833.99594,
+    "geom:area_square_m":3729819288.840959,
     "geom:bbox":"0.081524,7.946309,0.731428,8.779339",
     "geom:latitude":8.381685,
     "geom:longitude":0.389543,
@@ -84,9 +84,10 @@
         "hasc:id":"GH.TV.NK",
         "wd:id":"Q977886"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330097,
-    "wof:geomhash":"9889eece51a6e758a21889ca0b9237ad",
+    "wof:geomhash":"1b70f2e838c0c25c63023f1cd1bd3681",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -96,7 +97,7 @@
         }
     ],
     "wof:id":1108759989,
-    "wof:lastmodified":1690921660,
+    "wof:lastmodified":1695886303,
     "wof:name":"Nkwanta",
     "wof:parent_id":85671357,
     "wof:placetype":"county",

--- a/data/110/875/999/1/1108759991.geojson
+++ b/data/110/875/999/1/1108759991.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.045151,
-    "geom:area_square_m":555260136.490038,
+    "geom:area_square_m":555260136.490035,
     "geom:bbox":"0.515254316384,5.76208353,0.754707763609,6.16146276716",
     "geom:latitude":5.985462,
     "geom:longitude":0.651402,
@@ -78,9 +78,10 @@
         "hasc:id":"GH.TV.ST",
         "wd:id":"Q1433337"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330099,
-    "wof:geomhash":"1aa80913ec0c82ee3a24431cbbc419af",
+    "wof:geomhash":"44b999bc8ac9d1a10ff746b216d091d7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":1108759991,
-    "wof:lastmodified":1566638244,
+    "wof:lastmodified":1695886305,
     "wof:name":"Sogakope",
     "wof:parent_id":85671357,
     "wof:placetype":"county",

--- a/data/110/875/999/3/1108759993.geojson
+++ b/data/110/875/999/3/1108759993.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.040968,
-    "geom:area_square_m":504768590.696636,
+    "geom:area_square_m":504768792.606566,
     "geom:bbox":"-2.202249,4.735417,-1.811399,4.927043",
     "geom:latitude":4.84141,
     "geom:longitude":-2.012499,
@@ -115,9 +115,10 @@
         "hasc:id":"GH.WP.AW",
         "wd:id":"Q399949"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330100,
-    "wof:geomhash":"eb49bdc83b1f6ae3935e8581bbbd035e",
+    "wof:geomhash":"9f65cb97866188f54fd47592e1569b63",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -127,7 +128,7 @@
         }
     ],
     "wof:id":1108759993,
-    "wof:lastmodified":1690921666,
+    "wof:lastmodified":1695886623,
     "wof:name":"Ahanta West",
     "wof:parent_id":85671347,
     "wof:placetype":"county",

--- a/data/110/875/999/7/1108759997.geojson
+++ b/data/110/875/999/7/1108759997.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.227725,
-    "geom:area_square_m":2801510408.999076,
+    "geom:area_square_m":2801510285.367657,
     "geom:bbox":"-3.093231,5.345369,-2.486319,6.172079",
     "geom:latitude":5.784421,
     "geom:longitude":-2.78353,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"GH.WP.AS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330101,
-    "wof:geomhash":"9ebe7bda318af8cef00ef221848680b4",
+    "wof:geomhash":"5cacc334cf7a762ec92bd99c986955c1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108759997,
-    "wof:lastmodified":1627522153,
+    "wof:lastmodified":1695886623,
     "wof:name":"Aowin/ Suaman",
     "wof:parent_id":85671347,
     "wof:placetype":"county",

--- a/data/110/875/999/9/1108759999.geojson
+++ b/data/110/875/999/9/1108759999.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.083565,
-    "geom:area_square_m":1027083698.555919,
+    "geom:area_square_m":1027083705.513751,
     "geom:bbox":"-2.437319,6.100727,-2.092529,6.500567",
     "geom:latitude":6.285129,
     "geom:longitude":-2.262497,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"GH.WP.BA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330103,
-    "wof:geomhash":"90c4d869c577fa16a9b3ceb73ab061f6",
+    "wof:geomhash":"392b88cf032f6dc7eb425ee823192c73",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108759999,
-    "wof:lastmodified":1627522154,
+    "wof:lastmodified":1695886624,
     "wof:name":"Bibiani Anhwiaso",
     "wof:parent_id":85671347,
     "wof:placetype":"county",

--- a/data/110/876/000/1/1108760001.geojson
+++ b/data/110/876/000/1/1108760001.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.117463,
-    "geom:area_square_m":1446545814.581453,
+    "geom:area_square_m":1446545653.407743,
     "geom:bbox":"-3.110861,4.975774,-2.48231,5.407243",
     "geom:latitude":5.16728,
     "geom:longitude":-2.680297,
@@ -87,9 +87,10 @@
         "hasc:id":"GH.WP.JO",
         "wd:id":"Q1702699"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330104,
-    "wof:geomhash":"98c83a71d9c51fb6da6d3db3273e229a",
+    "wof:geomhash":"50adb81c9d5fa5592df0cec5b9138592",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -99,7 +100,7 @@
         }
     ],
     "wof:id":1108760001,
-    "wof:lastmodified":1627522155,
+    "wof:lastmodified":1695886625,
     "wof:name":"Jomoro",
     "wof:parent_id":85671347,
     "wof:placetype":"county",

--- a/data/110/876/000/3/1108760003.geojson
+++ b/data/110/876/000/3/1108760003.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.342763,
-    "geom:area_square_m":4210880947.295938,
+    "geom:area_square_m":4210880807.354954,
     "geom:bbox":"-3.260676,6.097872,-2.657083,7.003051",
     "geom:latitude":6.520611,
     "geom:longitude":-2.979883,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"GH.WP.JB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330106,
-    "wof:geomhash":"f7a87b5a9242b295f201125d507c4c4c",
+    "wof:geomhash":"0255497effbfa87d39b1811486158e7c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108760003,
-    "wof:lastmodified":1627522155,
+    "wof:lastmodified":1695886625,
     "wof:name":"Juabeso/ Bia",
     "wof:parent_id":85671347,
     "wof:placetype":"county",

--- a/data/110/876/000/5/1108760005.geojson
+++ b/data/110/876/000/5/1108760005.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.163497,
-    "geom:area_square_m":2013106272.514603,
+    "geom:area_square_m":2013106358.5944,
     "geom:bbox":"-1.988381,4.901716,-1.436478,5.632496",
     "geom:latitude":5.271334,
     "geom:longitude":-1.718249,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"GH.WP.MW"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330107,
-    "wof:geomhash":"a1ae83a768567991011efd0798b4e86b",
+    "wof:geomhash":"41ae2d2924e1ae245cdc170da5d5682a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108760005,
-    "wof:lastmodified":1627522155,
+    "wof:lastmodified":1695886625,
     "wof:name":"Mpohor Wassa East",
     "wof:parent_id":85671347,
     "wof:placetype":"county",

--- a/data/110/876/000/7/1108760007.geojson
+++ b/data/110/876/000/7/1108760007.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.175291,
-    "geom:area_square_m":2158845078.504574,
+    "geom:area_square_m":2158845333.841947,
     "geom:bbox":"-2.559549,4.818722,-2.09691,5.398509",
     "geom:latitude":5.122337,
     "geom:longitude":-2.307355,
@@ -102,9 +102,10 @@
         "hasc:id":"GH.WP.NE",
         "wd:id":"Q991487"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330109,
-    "wof:geomhash":"9b7113e23d429d13567018af8ec29509",
+    "wof:geomhash":"22c2800fee6ceb98f8af44941b104fd6",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -114,7 +115,7 @@
         }
     ],
     "wof:id":1108760007,
-    "wof:lastmodified":1690921682,
+    "wof:lastmodified":1695886626,
     "wof:name":"Nzema East",
     "wof:parent_id":85671347,
     "wof:placetype":"county",

--- a/data/110/876/000/9/1108760009.geojson
+++ b/data/110/876/000/9/1108760009.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.199656,
-    "geom:area_square_m":2454441892.775098,
+    "geom:area_square_m":2454441567.855079,
     "geom:bbox":"-2.946978,5.917956,-2.337729,6.521436",
     "geom:latitude":6.176995,
     "geom:longitude":-2.618994,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"GH.WP.SW"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330111,
-    "wof:geomhash":"bffe1459236872ece640129c1a4a4d4f",
+    "wof:geomhash":"4701aa97cf4cd6805301ef5ac3bf0bd1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108760009,
-    "wof:lastmodified":1627522156,
+    "wof:lastmodified":1695886626,
     "wof:name":"Sefwi Wiaso",
     "wof:parent_id":85671347,
     "wof:placetype":"county",

--- a/data/110/876/001/1/1108760011.geojson
+++ b/data/110/876/001/1/1108760011.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.030938,
-    "geom:area_square_m":381103887.956184,
+    "geom:area_square_m":381103824.269414,
     "geom:bbox":"-1.850814,4.868722,-1.559127,5.103475",
     "geom:latitude":4.99053,
     "geom:longitude":-1.71984,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"GH.WP.SA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330112,
-    "wof:geomhash":"5c2ffb53280ee961df46f4a841649d1f",
+    "wof:geomhash":"dfca5d09734f64cf112afbafe5fc3a8a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108760011,
-    "wof:lastmodified":1627522156,
+    "wof:lastmodified":1695886626,
     "wof:name":"Shama Ahanta East",
     "wof:parent_id":85671347,
     "wof:placetype":"county",

--- a/data/110/876/001/5/1108760015.geojson
+++ b/data/110/876/001/5/1108760015.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.401169,
-    "geom:area_square_m":4935615330.359058,
+    "geom:area_square_m":4935615284.917389,
     "geom:bbox":"-2.620783,5.344206,-1.721975,6.112571",
     "geom:latitude":5.74307,
     "geom:longitude":-2.229907,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"GH.WP.WA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330113,
-    "wof:geomhash":"df84004b3659257c3662f39277585c97",
+    "wof:geomhash":"72c75e44bf8162be67771556140b8137",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108760015,
-    "wof:lastmodified":1627522157,
+    "wof:lastmodified":1695886626,
     "wof:name":"Wassa Amenfi",
     "wof:parent_id":85671347,
     "wof:placetype":"county",

--- a/data/110/876/001/7/1108760017.geojson
+++ b/data/110/876/001/7/1108760017.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.213543,
-    "geom:area_square_m":2629105057.444252,
+    "geom:area_square_m":2629104919.325808,
     "geom:bbox":"-2.236273,4.90353,-1.773061,5.65979",
     "geom:latitude":5.321187,
     "geom:longitude":-1.997686,
@@ -87,9 +87,10 @@
         "hasc:id":"GH.WP.WW",
         "wd:id":"Q673640"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"GH",
     "wof:created":1481330114,
-    "wof:geomhash":"4c085e6bad729c4b4c7c78f8db6b8726",
+    "wof:geomhash":"bd6b944e74c2410bc79b65f585ffc79f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -99,7 +100,7 @@
         }
     ],
     "wof:id":1108760017,
-    "wof:lastmodified":1627522157,
+    "wof:lastmodified":1695886626,
     "wof:name":"Wassa West",
     "wof:parent_id":85671347,
     "wof:placetype":"county",

--- a/data/856/321/89/85632189.geojson
+++ b/data/856/321/89/85632189.geojson
@@ -1160,6 +1160,7 @@
         "hasc:id":"GH",
         "icao:code":"9G",
         "ioc:id":"GHA",
+        "iso:code":"GH",
         "itu:id":"GHA",
         "loc:id":"n80061117",
         "m49:code":"288",
@@ -1174,6 +1175,7 @@
         "wk:page":"Ghana",
         "wmo:id":"GH"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GH",
     "wof:country_alpha3":"GHA",
     "wof:geom_alt":[
@@ -1198,7 +1200,7 @@
         "ewe",
         "gaa"
     ],
-    "wof:lastmodified":1694639549,
+    "wof:lastmodified":1695881207,
     "wof:name":"Ghana",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/713/19/85671319.geojson
+++ b/data/856/713/19/85671319.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":5.740421,
-    "geom:area_square_m":70034815394.512207,
+    "geom:area_square_m":70034815595.402145,
     "geom:bbox":"-2.78023,7.96566,0.566955,10.707606",
     "geom:latitude":9.348013,
     "geom:longitude":-0.969633,
@@ -322,17 +322,19 @@
         "gn:id":2297169,
         "gp:id":2345467,
         "hasc:id":"GH.NP",
+        "iso:code":"GH-NP",
         "iso:id":"GH-NP",
         "qs_pg:id":894885,
         "unlc:id":"GH-NP",
         "wd:id":"Q502215",
         "wk:page":"Northern Region (Ghana)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GH",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"fe0ec6b722de8cddbdfd68d090fb0510",
+    "wof:geomhash":"9449759b29b8f194e2e9680a6311ac07",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -350,7 +352,7 @@
         "ewe",
         "gaa"
     ],
-    "wof:lastmodified":1690921652,
+    "wof:lastmodified":1695884925,
     "wof:name":"Northern",
     "wof:parent_id":85632189,
     "wof:placetype":"region",

--- a/data/856/713/23/85671323.geojson
+++ b/data/856/713/23/85671323.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.740433,
-    "geom:area_square_m":8994191523.957752,
+    "geom:area_square_m":8994192104.85145,
     "geom:bbox":"-1.591245,10.281437,0.034421,11.166667",
     "geom:latitude":10.773294,
     "geom:longitude":-0.817656,
@@ -329,17 +329,19 @@
         "gn:id":2294291,
         "gp:id":2345470,
         "hasc:id":"GH.UE",
+        "iso:code":"GH-UE",
         "iso:id":"GH-UE",
         "qs_pg:id":191331,
         "unlc:id":"GH-UE",
         "wd:id":"Q712828",
         "wk:page":"Upper East Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GH",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e1a264ab7dbdbcd8d7ff7deeeefb9eff",
+    "wof:geomhash":"cbb96df1a2f166553550e51b1945bdb6",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -357,7 +359,7 @@
         "ewe",
         "gaa"
     ],
-    "wof:lastmodified":1690921655,
+    "wof:lastmodified":1695884926,
     "wof:name":"Upper East",
     "wof:parent_id":85632189,
     "wof:placetype":"region",

--- a/data/856/713/27/85671327.geojson
+++ b/data/856/713/27/85671327.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.54678,
-    "geom:area_square_m":18810795350.588001,
+    "geom:area_square_m":18810795475.337662,
     "geom:bbox":"-2.933057,9.620274,-1.445153,11.028334",
     "geom:latitude":10.414364,
     "geom:longitude":-2.213551,
@@ -332,17 +332,19 @@
         "gn:id":2294286,
         "gp:id":2345471,
         "hasc:id":"GH.UW",
+        "iso:code":"GH-UW",
         "iso:id":"GH-UW",
         "qs_pg:id":1142818,
         "unlc:id":"GH-UW",
         "wd:id":"Q715805",
         "wk:page":"Upper West Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GH",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c4f5d25af5102271091802efc430778c",
+    "wof:geomhash":"e8cab428a89372e4974e3eab97f46c0a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -360,7 +362,7 @@
         "ewe",
         "gaa"
     ],
-    "wof:lastmodified":1690921651,
+    "wof:lastmodified":1695884925,
     "wof:name":"Upper West",
     "wof:parent_id":85632189,
     "wof:placetype":"region",

--- a/data/856/713/31/85671331.geojson
+++ b/data/856/713/31/85671331.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.990493,
-    "geom:area_square_m":24438541121.158249,
+    "geom:area_square_m":24438540902.347691,
     "geom:bbox":"-2.448857,5.874113,-0.242308,7.62982",
     "geom:latitude":6.810182,
     "geom:longitude":-1.449067,
@@ -350,17 +350,19 @@
         "gn:id":2304116,
         "gp:id":2345463,
         "hasc:id":"GH.AH",
+        "iso:code":"GH-AH",
         "iso:id":"GH-AH",
         "qs_pg:id":239504,
         "unlc:id":"GH-AH",
         "wd:id":"Q398417",
         "wk:page":"Ashanti Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GH",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1195107c1632bb115ab4ba251ffad29f",
+    "wof:geomhash":"577524e9e9027421959de14bc3a66427",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -378,7 +380,7 @@
         "ewe",
         "gaa"
     ],
-    "wof:lastmodified":1690921653,
+    "wof:lastmodified":1695884926,
     "wof:name":"Ashanti",
     "wof:parent_id":85632189,
     "wof:placetype":"region",

--- a/data/856/713/37/85671337.geojson
+++ b/data/856/713/37/85671337.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.260873,
-    "geom:area_square_m":39956826547.407394,
+    "geom:area_square_m":39956827905.860466,
     "geom:bbox":"-3.117319,6.363657,0.256151,8.759931",
     "geom:latitude":7.69568,
     "geom:longitude":-1.652319,
@@ -316,17 +316,19 @@
         "gn:id":2302547,
         "gp:id":2345464,
         "hasc:id":"GH.BA",
+        "iso:code":"GH-BA",
         "iso:id":"GH-BA",
         "qs_pg:id":219557,
         "unlc:id":"GH-BA",
         "wd:id":"Q397737",
         "wk:page":"Brong-Ahafo Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GH",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"bf41c7f251f68487370fd1496eae919d",
+    "wof:geomhash":"977f1cabcd2b64699b42bcfd37035c6e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -344,7 +346,7 @@
         "ewe",
         "gaa"
     ],
-    "wof:lastmodified":1690921654,
+    "wof:lastmodified":1695884926,
     "wof:name":"Brong Ahafo",
     "wof:parent_id":85632189,
     "wof:placetype":"region",

--- a/data/856/713/41/85671341.geojson
+++ b/data/856/713/41/85671341.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.805935,
-    "geom:area_square_m":9918474360.926064,
+    "geom:area_square_m":9918475032.086964,
     "geom:bbox":"-2.16852,5.030416,-0.366651,6.326416",
     "geom:latitude":5.565615,
     "geom:longitude":-1.210832,
@@ -325,17 +325,19 @@
         "gn:id":2302353,
         "gp:id":2345465,
         "hasc:id":"GH.CP",
+        "iso:code":"GH-CP",
         "iso:id":"GH-CP",
         "qs_pg:id":890065,
         "unlc:id":"GH-CP",
         "wd:id":"Q846323",
         "wk:page":"Central Region (Ghana)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GH",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1f727daf6def943571210bc4dd793ce3",
+    "wof:geomhash":"f0a18b806f07091264d7c9a4039cd320",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -353,7 +355,7 @@
         "ewe",
         "gaa"
     ],
-    "wof:lastmodified":1690921655,
+    "wof:lastmodified":1695884926,
     "wof:name":"Central",
     "wof:parent_id":85632189,
     "wof:placetype":"region",

--- a/data/856/713/43/85671343.geojson
+++ b/data/856/713/43/85671343.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.563785,
-    "geom:area_square_m":19214965007.637669,
+    "geom:area_square_m":19214964870.611763,
     "geom:bbox":"-1.251194,5.705611,0.247341,7.203637",
     "geom:latitude":6.415804,
     "geom:longitude":-0.441829,
@@ -322,17 +322,19 @@
         "gn:id":2301360,
         "gp:id":2345466,
         "hasc:id":"GH.EP",
+        "iso:code":"GH-EP",
         "iso:id":"GH-EP",
         "qs_pg:id":890066,
         "unlc:id":"GH-EP",
         "wd:id":"Q405670",
         "wk:page":"Eastern Region (Ghana)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GH",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ede1a382656f858b3168ff92d74ff84d",
+    "wof:geomhash":"b7e22b934432cee31525e02baff470ef",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -350,7 +352,7 @@
         "ewe",
         "gaa"
     ],
-    "wof:lastmodified":1690921653,
+    "wof:lastmodified":1695884926,
     "wof:name":"Eastern",
     "wof:parent_id":85632189,
     "wof:placetype":"region",

--- a/data/856/713/47/85671347.geojson
+++ b/data/856/713/47/85671347.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.996576,
-    "geom:area_square_m":24563006979.68354,
+    "geom:area_square_m":24563006539.360462,
     "geom:bbox":"-3.260676,4.735417,-1.436478,7.003051",
     "geom:latitude":5.745064,
     "geom:longitude":-2.416273,
@@ -325,17 +325,19 @@
         "gn:id":2294076,
         "gp:id":2345469,
         "hasc:id":"GH.WP",
+        "iso:code":"GH-WP",
         "iso:id":"GH-WP",
         "qs_pg:id":191322,
         "unlc:id":"GH-WP",
         "wd:id":"Q870155",
         "wk:page":"Western Region (Ghana)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GH",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1732e795eec50234be996a1c5a7fde99",
+    "wof:geomhash":"caa9d1c5c00f231e92506b35c1e10eb9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -353,7 +355,7 @@
         "ewe",
         "gaa"
     ],
-    "wof:lastmodified":1690921656,
+    "wof:lastmodified":1695884926,
     "wof:name":"Western",
     "wof:parent_id":85632189,
     "wof:placetype":"region",

--- a/data/856/713/53/85671353.geojson
+++ b/data/856/713/53/85671353.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.306129,
-    "geom:area_square_m":3765843942.321328,
+    "geom:area_square_m":3765843454.592579,
     "geom:bbox":"-0.494539,5.494181,0.675417,6.126875",
     "geom:latitude":5.816251,
     "geom:longitude":0.064027,
@@ -354,17 +354,19 @@
         "gn:id":2300569,
         "gp:id":2345462,
         "hasc:id":"GH.AA",
+        "iso:code":"GH-AA",
         "iso:id":"GH-AA",
         "qs_pg:id":219556,
         "unlc:id":"GH-AA",
         "wd:id":"Q431729",
         "wk:page":"Greater Accra Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GH",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c992594472cf35037ee1cb7bcd5ff24e",
+    "wof:geomhash":"b39ab7337facc824eb49f2627fa63ecf",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -382,7 +384,7 @@
         "ewe",
         "gaa"
     ],
-    "wof:lastmodified":1690921654,
+    "wof:lastmodified":1695884926,
     "wof:name":"Greater Accra",
     "wof:parent_id":85632189,
     "wof:placetype":"region",

--- a/data/856/713/57/85671357.geojson
+++ b/data/856/713/57/85671357.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.665034,
-    "geom:area_square_m":20421197123.366734,
+    "geom:area_square_m":20421200691.261696,
     "geom:bbox":"-0.382064,5.762055,1.199479,8.779339",
     "geom:latitude":7.256618,
     "geom:longitude":0.410181,
@@ -313,17 +313,19 @@
         "gn:id":2294234,
         "gp:id":2345468,
         "hasc:id":"GH.TV",
+        "iso:code":"GH-TV",
         "iso:id":"GH-TV",
         "qs_pg:id":894886,
         "unlc:id":"GH-TV",
         "wd:id":"Q712832",
         "wk:page":"Volta Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"GH",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6e007ed30743ea209c88853362697b7c",
+    "wof:geomhash":"cb1a2948d2478d4af2ba312321ffccd9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -341,7 +343,7 @@
         "ewe",
         "gaa"
     ],
-    "wof:lastmodified":1690921651,
+    "wof:lastmodified":1695884925,
     "wof:name":"Volta",
     "wof:parent_id":85632189,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.